### PR TITLE
Add initial support for `erasue` parameter on `Storage` resource

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -23,3 +23,10 @@ const (
 	DefaultDomain    = "root"
 	TenantNameFormat = "/%s/%s"
 )
+
+type ErasureType string
+
+const (
+	ErasureBlock42   ErasureType = "block-4-2"
+	ErasureMirror3DC ErasureType = "mirror-3-dc"
+)

--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -13,6 +13,13 @@ type StorageSpec struct {
 	// ConfigMap name with custom YDB configuration, where key is config file name and value is config file content.
 	// +optional
 	ClusterConfig string `json:"config,omitempty"`
+	// Data storage mode.
+	// For details, see https://cloud.yandex.ru/docs/ydb/oss/public/administration/deploy/production_checklist#topologiya
+	// TODO English docs link
+	// FIXME mirror-3-dc is only supported with external configuration
+	// +kubebuilder:validation:Enum=mirror-3-dc;block-4-2
+	// +kubebuilder:default:=block-4-2
+	Erasure ErasureType `json:"erasure"`
 	// Where cluster data should be kept
 	// +required
 	DataStore []corev1.PersistentVolumeClaimSpec `json:"dataStore"`

--- a/deploy/ydb-operator/crds/storage.yaml
+++ b/deploy/ydb-operator/crds/storage.yaml
@@ -1048,6 +1048,15 @@ spec:
                 maxLength: 63
                 pattern: '[a-zA-Z0-9]([-_a-zA-Z0-9]*[a-zA-Z0-9])?'
                 type: string
+              erasure:
+                default: block-4-2
+                description: Data storage mode. For details, see https://cloud.yandex.ru/docs/ydb/oss/public/administration/deploy/production_checklist#topologiya
+                  TODO English docs link FIXME mirror-3-dc is only supported with
+                  external configuration
+                enum:
+                - mirror-3-dc
+                - block-4-2
+                type: string
               image:
                 description: Container image information
                 properties:
@@ -1413,6 +1422,7 @@ spec:
                 type: string
             required:
             - dataStore
+            - erasure
             - nodes
             type: object
           status:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Support `erasure` field on `Storage` CRD
- Enable `topologySpreadConstraints` in case of `mirror-3-dc` erasure
