### PR TITLE
Fix storage init command

### DIFF
--- a/internal/controllers/storage/init.go
+++ b/internal/controllers/storage/init.go
@@ -50,17 +50,20 @@ func (r *StorageReconciler) runInitScripts(ctx context.Context, storage *resourc
 	if !meta.IsStatusConditionTrue(storage.Status.Conditions, InitStorageStepCondition) {
 		cmd := []string{
 			fmt.Sprintf("%s/%s", v1alpha1.BinariesDir, v1alpha1.DaemonBinaryName),
-			"admin", "blobstorage", "config", "init",
-			"--yaml-file",
-			fmt.Sprintf("%s/%s", v1alpha1.ConfigDir, v1alpha1.ConfigFileName),
 		}
-
 		if storage.Spec.Service.GRPC.TLSConfiguration.Enabled {
 			cmd = append(
 				cmd,
 				"-s", storage.GetGRPCEndpointWithProto(),
 			)
 		}
+		cmd = append(
+			cmd,
+			"admin", "blobstorage", "config", "init",
+			"--yaml-file",
+			fmt.Sprintf("%s/%s", v1alpha1.ConfigDir, v1alpha1.ConfigFileName),
+		)
+
 		_, _, err := exec.ExecInPod(r.Scheme, r.Config, storage.Namespace, podName, "ydb-storage", cmd)
 		if err != nil {
 			return Stop, ctrl.Result{RequeueAfter: StorageInitializationRequeueDelay}, err


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Storage initialization failed with message:
`"error": "failed to stream execution results back, stdout:\n\"\"stderr:\n\"(NLastGetopt::TUsageException) unknown option 's' in '-s'\nTry 'init --help' for more information.\n\": command terminated with exit code 1",`

Incorrect position of arguments `-s grpc://endpoint`. These are global arguments and must be before any other arguments.

Issue Number: N/A

## What is the new behavior?

Sequence of arguments has been fixed

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
