### PR TITLE
Set name_label=name for metrics in ydb service

### DIFF
--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4
+version: 0.4.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.8"
+appVersion: "0.4.9"

--- a/deploy/ydb-operator/values.yaml
+++ b/deploy/ydb-operator/values.yaml
@@ -6,7 +6,7 @@ image:
   ##
   pullPolicy: IfNotPresent
   repository: cr.yandex/yc/ydb-kubernetes-operator
-  tag: 0.4.8
+  tag: 0.4.9
 
 ## Secrets to use for Docker registry access
 ## Secrets must be provided manually.

--- a/internal/metrics/const.go
+++ b/internal/metrics/const.go
@@ -28,6 +28,7 @@ var storageMetricsServices = []string{ // NB dashes are not allowed in the metri
 
 var databaseMetricsServices = []string{ // NB dashes are not allowed in the metric service name
 	"ydb",
+	"ydb_serverless",
 	"auth",
 	"coordinator",
 	"dsproxy_queue",

--- a/internal/metrics/endpoints.go
+++ b/internal/metrics/endpoints.go
@@ -16,9 +16,15 @@ func getMetricsServices(services []string) []MetricsService {
 	var metricsServices []MetricsService
 
 	for _, serviceName := range storageMetricsServices {
+		var servicePath string
+		if serviceName == "ydb" || serviceName == "ydb_serverless" {
+			servicePath = fmt.Sprintf(MetricEndpointFormat, serviceName+"/name_label=name")
+		} else {
+			servicePath = fmt.Sprintf(MetricEndpointFormat, serviceName)
+		}
 		metricsServices = append(metricsServices, MetricsService{
 			Name:        serviceName,
-			Path:        fmt.Sprintf(MetricEndpointFormat, serviceName),
+			Path:        servicePath,
 			Relabelings: GetMetricsRelabelings(serviceName),
 		})
 	}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->
Change metrics collection path for services ydb and ydb_serverless

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Current path `/counters/counters=ydb/prometheus`

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- add name_label=name in metrics collection path for ydb and ydb_serverless services
- add metrics service ydb_serverless
- bump versions

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
