### PR TITLE
Webhook URL + NodePort support

### DIFF
--- a/deploy/ydb-operator/templates/webhooks/certificate.yaml
+++ b/deploy/ydb-operator/templates/webhooks/certificate.yaml
@@ -6,7 +6,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ template "ydb.fullname" . }}-self-signed-issuer
-  namespace: {{ template "ydb.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 ---

--- a/deploy/ydb-operator/templates/webhooks/certificate.yaml
+++ b/deploy/ydb-operator/templates/webhooks/certificate.yaml
@@ -48,6 +48,9 @@ spec:
     name: {{ template "ydb.fullname" . }}-root-issuer
     {{- end }}
   dnsNames:
+  {{- if .Values.webhook.service.url }}
+  - {{ .Values.webhook.service.url }}
+  {{- end}}
   - {{ template "ydb.fullname" . }}-webhook
   - {{ template "ydb.fullname" . }}-webhook.{{ .Release.Namespace }}
   - {{ template "ydb.fullname" . }}-webhook.{{ .Release.Namespace }}.svc

--- a/deploy/ydb-operator/templates/webhooks/certificate.yaml
+++ b/deploy/ydb-operator/templates/webhooks/certificate.yaml
@@ -48,8 +48,8 @@ spec:
     name: {{ template "ydb.fullname" . }}-root-issuer
     {{- end }}
   dnsNames:
-  {{- if .Values.webhook.service.url }}
-  - {{ .Values.webhook.service.url }}
+  {{- if .Values.webhook.service.fqdn }}
+  - {{ .Values.webhook.service.fqdn }}
   {{- end}}
   - {{ template "ydb.fullname" . }}-webhook
   - {{ template "ydb.fullname" . }}-webhook.{{ .Release.Namespace }}

--- a/deploy/ydb-operator/templates/webhooks/job-patch/job-createSecret.yaml
+++ b/deploy/ydb-operator/templates/webhooks/job-patch/job-createSecret.yaml
@@ -38,7 +38,7 @@ spec:
           imagePullPolicy: {{ .Values.webhook.patch.image.pullPolicy }}
           args:
             - create
-            - --host={{ template "ydb.fullname" . }}-webhook,{{ template "ydb.fullname" . }}-webhook.{{ .Release.Namespace }}.svc
+            - --host={{ template "ydb.fullname" . }}-webhook,{{ template "ydb.fullname" . }}-webhook.{{ .Release.Namespace }}.svc,{{ if .Values.webhook.service.url }}{{ .Values.webhook.service.url }}{{ end }}
             - --namespace={{ .Release.Namespace }}
             - --secret-name={{ template "ydb.fullname" . }}-webhook
           resources:

--- a/deploy/ydb-operator/templates/webhooks/job-patch/job-createSecret.yaml
+++ b/deploy/ydb-operator/templates/webhooks/job-patch/job-createSecret.yaml
@@ -38,7 +38,7 @@ spec:
           imagePullPolicy: {{ .Values.webhook.patch.image.pullPolicy }}
           args:
             - create
-            - --host={{ template "ydb.fullname" . }}-webhook,{{ template "ydb.fullname" . }}-webhook.{{ .Release.Namespace }}.svc,{{ if .Values.webhook.service.url }}{{ .Values.webhook.service.url }}{{ end }}
+            - --host={{ template "ydb.fullname" . }}-webhook,{{ template "ydb.fullname" . }}-webhook.{{ .Release.Namespace }}.svc{{ if .Values.webhook.service.fqdn }},{{ .Values.webhook.service.fqdn }}{{ end }}
             - --namespace={{ .Release.Namespace }}
             - --secret-name={{ template "ydb.fullname" . }}-webhook
           resources:

--- a/deploy/ydb-operator/templates/webhooks/service.yaml
+++ b/deploy/ydb-operator/templates/webhooks/service.yaml
@@ -12,6 +12,9 @@ spec:
       targetPort: webhook
       protocol: TCP
       name: webhook
+      {{- if eq .Values.webhook.service.type "NodePort" }}
+      nodePort: {{ .Values.webhook.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "ydb.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/deploy/ydb-operator/templates/webhooks/webhooks.yaml
+++ b/deploy/ydb-operator/templates/webhooks/webhooks.yaml
@@ -8,14 +8,22 @@ webhooks:
   {{- if eq .Values.webhook.service.type "NodePort" }}
     {{- $webhookPort = coalesce .Values.webhook.service.nodePort 9443 -}}
   {{- end }}
+  {{- $webhookUrl := .Values.webhook.service.url -}}
+  {{- if not hasPrefix $webhookUrl "https://" }}
+    {{- $webhookUrl = "https://"$webhookUrl -}}
+  {{- end }}
   - admissionReviewVersions:
       - v1
     clientConfig:
+      {{- if .Values.webhook.service.url }}
+      url: {{ $webhookUrl }}:{{ $webhookPort }}/mutate-ydb-tech-v1alpha1-database 
+      {{- else}}
       service:
         name: {{ template "ydb.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         port: {{ $webhookPort }}
         path: /mutate-ydb-tech-v1alpha1-database
+      {{- end}}
     failurePolicy: Fail
     name: mutate-database.ydb.tech
     rules:
@@ -32,11 +40,15 @@ webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
+      {{- if .Values.webhook.service.url }}
+      url: {{ $webhookUrl }}:{{ $webhookPort }}/validate-ydb-tech-v1alpha1-database 
+      {{- else}}
       service:
         name: {{ template "ydb.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         port: {{ $webhookPort }}
         path: /validate-ydb-tech-v1alpha1-database
+      {{- end}}
     failurePolicy: Fail
     name: validate-database.ydb.tech
     rules:
@@ -53,11 +65,15 @@ webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
+      {{- if .Values.webhook.service.url }}
+      url: {{ $webhookUrl }}:{{ $webhookPort }}/mutate-ydb-tech-v1alpha1-storage 
+      {{- else}}
       service:
         name: {{ template "ydb.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         port: {{ $webhookPort }}
         path: /mutate-ydb-tech-v1alpha1-storage
+      {{- end}}
     failurePolicy: Fail
     name: mutate-storage.ydb.tech
     rules:
@@ -74,11 +90,15 @@ webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
+      {{- if .Values.webhook.service.url }}
+      url: {{ $webhookUrl }}:{{ $webhookPort }}/validate-ydb-tech-v1alpha1-storage
+      {{- else}}
       service:
         name: {{ template "ydb.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         port: {{ $webhookPort }}
         path: /validate-ydb-tech-v1alpha1-storage
+      {{- end}}
     failurePolicy: Fail
     name: validate-storage.ydb.tech
     rules:

--- a/deploy/ydb-operator/templates/webhooks/webhooks.yaml
+++ b/deploy/ydb-operator/templates/webhooks/webhooks.yaml
@@ -9,13 +9,15 @@ webhooks:
     {{- $webhookPort = coalesce .Values.webhook.service.nodePort 9443 -}}
   {{- end }}
   {{- $webhookUrl := .Values.webhook.service.url -}}
-  {{- if not hasPrefix $webhookUrl "https://" }}
-    {{- $webhookUrl = "https://"$webhookUrl -}}
-  {{- end }}
+  {{- if not (empty $webhookUrl) }}
+    {{- if not (hasPrefix $webhookUrl "https://") }}
+      {{- $webhookUrl = printf "https://%s" $webhookUrl -}}
+    {{- end}}
+  {{- end}}
   - admissionReviewVersions:
       - v1
     clientConfig:
-      {{- if .Values.webhook.service.url }}
+      {{- if not (empty $webhookUrl) }}
       url: {{ $webhookUrl }}:{{ $webhookPort }}/mutate-ydb-tech-v1alpha1-database 
       {{- else}}
       service:
@@ -40,7 +42,7 @@ webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
-      {{- if .Values.webhook.service.url }}
+      {{- if not (empty $webhookUrl) }}
       url: {{ $webhookUrl }}:{{ $webhookPort }}/validate-ydb-tech-v1alpha1-database 
       {{- else}}
       service:
@@ -65,7 +67,7 @@ webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
-      {{- if .Values.webhook.service.url }}
+      {{- if not (empty $webhookUrl) }}
       url: {{ $webhookUrl }}:{{ $webhookPort }}/mutate-ydb-tech-v1alpha1-storage 
       {{- else}}
       service:
@@ -90,7 +92,7 @@ webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
-      {{- if .Values.webhook.service.url }}
+      {{- if not (empty $webhookUrl) }}
       url: {{ $webhookUrl }}:{{ $webhookPort }}/validate-ydb-tech-v1alpha1-storage
       {{- else}}
       service:

--- a/deploy/ydb-operator/templates/webhooks/webhooks.yaml
+++ b/deploy/ydb-operator/templates/webhooks/webhooks.yaml
@@ -4,13 +4,17 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "ydb.fullname" . }}-webhook
 webhooks:
+  {{- $webhookPort := .Values.webhook.service.port -}}
+  {{- if eq .Values.webhook.service.type "NodePort" }}
+    {{- $webhookPort = coalesce .Values.webhook.service.nodePort 9443 -}}
+  {{- end }}
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
         name: {{ template "ydb.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
-        port: {{ .Values.webhook.service.port }}
+        port: {{ $webhookPort }}
         path: /mutate-ydb-tech-v1alpha1-database
     failurePolicy: Fail
     name: mutate-database.ydb.tech
@@ -31,7 +35,7 @@ webhooks:
       service:
         name: {{ template "ydb.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
-        port: {{ .Values.webhook.service.port }}
+        port: {{ $webhookPort }}
         path: /validate-ydb-tech-v1alpha1-database
     failurePolicy: Fail
     name: validate-database.ydb.tech
@@ -52,7 +56,7 @@ webhooks:
       service:
         name: {{ template "ydb.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
-        port: {{ .Values.webhook.service.port }}
+        port: {{ $webhookPort }}
         path: /mutate-ydb-tech-v1alpha1-storage
     failurePolicy: Fail
     name: mutate-storage.ydb.tech
@@ -73,7 +77,7 @@ webhooks:
       service:
         name: {{ template "ydb.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
-        port: {{ .Values.webhook.service.port }}
+        port: {{ $webhookPort }}
         path: /validate-ydb-tech-v1alpha1-storage
     failurePolicy: Fail
     name: validate-storage.ydb.tech

--- a/deploy/ydb-operator/templates/webhooks/webhooks.yaml
+++ b/deploy/ydb-operator/templates/webhooks/webhooks.yaml
@@ -4,21 +4,16 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "ydb.fullname" . }}-webhook
 webhooks:
+  {{- $webhookFqdn := .Values.webhook.service.fqdn -}}
   {{- $webhookPort := .Values.webhook.service.port -}}
   {{- if eq .Values.webhook.service.type "NodePort" }}
     {{- $webhookPort = coalesce .Values.webhook.service.nodePort 9443 -}}
   {{- end }}
-  {{- $webhookUrl := .Values.webhook.service.url -}}
-  {{- if not (empty $webhookUrl) }}
-    {{- if not (hasPrefix $webhookUrl "https://") }}
-      {{- $webhookUrl = printf "https://%s" $webhookUrl -}}
-    {{- end}}
-  {{- end}}
   - admissionReviewVersions:
       - v1
     clientConfig:
-      {{- if not (empty $webhookUrl) }}
-      url: {{ $webhookUrl }}:{{ $webhookPort }}/mutate-ydb-tech-v1alpha1-database 
+      {{- if not (empty $webhookFqdn) }}
+      url: https://{{ $webhookFqdn }}:{{ $webhookPort }}/mutate-ydb-tech-v1alpha1-database 
       {{- else}}
       service:
         name: {{ template "ydb.fullname" . }}-webhook
@@ -42,8 +37,8 @@ webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
-      {{- if not (empty $webhookUrl) }}
-      url: {{ $webhookUrl }}:{{ $webhookPort }}/validate-ydb-tech-v1alpha1-database 
+      {{- if not (empty $webhookFqdn) }}
+      url: https://{{ $webhookFqdn }}:{{ $webhookPort }}/validate-ydb-tech-v1alpha1-database 
       {{- else}}
       service:
         name: {{ template "ydb.fullname" . }}-webhook
@@ -67,8 +62,8 @@ webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
-      {{- if not (empty $webhookUrl) }}
-      url: {{ $webhookUrl }}:{{ $webhookPort }}/mutate-ydb-tech-v1alpha1-storage 
+      {{- if not (empty $webhookFqdn) }}
+      url: https://{{ $webhookFqdn }}:{{ $webhookPort }}/mutate-ydb-tech-v1alpha1-storage 
       {{- else}}
       service:
         name: {{ template "ydb.fullname" . }}-webhook
@@ -92,8 +87,8 @@ webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
-      {{- if not (empty $webhookUrl) }}
-      url: {{ $webhookUrl }}:{{ $webhookPort }}/validate-ydb-tech-v1alpha1-storage
+      {{- if not (empty $webhookFqdn) }}
+      url: https://{{ $webhookFqdn }}:{{ $webhookPort }}/validate-ydb-tech-v1alpha1-storage
       {{- else}}
       service:
         name: {{ template "ydb.fullname" . }}-webhook

--- a/deploy/ydb-operator/values.yaml
+++ b/deploy/ydb-operator/values.yaml
@@ -53,6 +53,9 @@ webhook:
     port: 9443
     ## If type is NodePort:
     #  nodePort: 9443
+    #
+    ## If url should be specified in WebhookConfiguration instead of service:
+    #  url: example.org
 
   ## If enabled, generate a self-signed certificate, then patch the webhook configurations with the generated data.
   ## On chart upgrades (or if the secret exists) the cert will not be re-generated. You can use this to provide your own

--- a/deploy/ydb-operator/values.yaml
+++ b/deploy/ydb-operator/values.yaml
@@ -54,8 +54,8 @@ webhook:
     ## If type is NodePort:
     #  nodePort: 9443
     #
-    ## If url should be specified in WebhookConfiguration instead of service:
-    #  url: example.org
+    ## Arbitrary fqdn for WebhookConfiguration instead of a default Service cluster fqdn:
+    #  fqdn: example.org
 
   ## If enabled, generate a self-signed certificate, then patch the webhook configurations with the generated data.
   ## On chart upgrades (or if the secret exists) the cert will not be re-generated. You can use this to provide your own

--- a/deploy/ydb-operator/values.yaml
+++ b/deploy/ydb-operator/values.yaml
@@ -51,6 +51,8 @@ webhook:
   service:
     type: ClusterIP
     port: 9443
+    ## If type is NodePort:
+    #  nodePort: 9443
 
   ## If enabled, generate a self-signed certificate, then patch the webhook configurations with the generated data.
   ## On chart upgrades (or if the secret exists) the cert will not be re-generated. You can use this to provide your own


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

- Added the feature to specify webhook endpoint as `url`, second option being `service`. Self-signed certificate will be issued for the specified url as well.
- `nodePort` can now be specified in webhook service configuration

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- `nodePort` cannot be specified
- `url` in WebhookConfiguration cannot be specified

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- user can use `nodePort` through the helm chart
- user can set `url` in WebhookConfiguration and expect TLS to work

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
