### PR TITLE
Remove ClusterConfig deprecated fields

### DIFF
--- a/api/v1alpha1/database_types.go
+++ b/api/v1alpha1/database_types.go
@@ -11,11 +11,6 @@ type DatabaseSpec struct {
 	// +required
 	Nodes int32 `json:"nodes"`
 
-	// ConfigMap name with custom YDB configuration, where key is config file name and value is config file content.
-	// +optional
-	// +deprecated
-	ClusterConfig string `json:"config,omitempty"`
-
 	// YDB configuration in YAML format. Will be applied on top of generated one in internal/configuration
 	// +optional
 	Configuration string `json:"configuration"`

--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -11,11 +11,6 @@ type StorageSpec struct {
 	// +required
 	Nodes int32 `json:"nodes"`
 
-	// ConfigMap name with custom YDB configuration, where key is config file name and value is config file content.
-	// +optional
-	// +deprecated
-	ClusterConfig string `json:"config,omitempty"`
-
 	// YDB configuration in YAML format. Will be applied on top of generated one in internal/configuration
 	// +optional
 	Configuration string `json:"configuration"`

--- a/deploy/ydb-operator/crds/database.yaml
+++ b/deploy/ydb-operator/crds/database.yaml
@@ -881,10 +881,6 @@ spec:
                         type: array
                     type: object
                 type: object
-              config:
-                description: ConfigMap name with custom YDB configuration, where key
-                  is config file name and value is config file content.
-                type: string
               configuration:
                 description: YDB configuration in YAML format. Will be applied on
                   top of generated one in internal/configuration
@@ -3654,10 +3650,6 @@ spec:
                             type: array
                         type: object
                     type: object
-                  config:
-                    description: ConfigMap name with custom YDB configuration, where
-                      key is config file name and value is config file content.
-                    type: string
                   configuration:
                     description: YDB configuration in YAML format. Will be applied
                       on top of generated one in internal/configuration

--- a/deploy/ydb-operator/crds/storage.yaml
+++ b/deploy/ydb-operator/crds/storage.yaml
@@ -881,10 +881,6 @@ spec:
                         type: array
                     type: object
                 type: object
-              config:
-                description: ConfigMap name with custom YDB configuration, where key
-                  is config file name and value is config file content.
-                type: string
               configuration:
                 description: YDB configuration in YAML format. Will be applied on
                   top of generated one in internal/configuration


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

Remove `ClusterConfig` entirely

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`config` field is accepted in Storage and Database resources, and yet has no effect, operator does not care about it

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

When user tries to specify the `config` field, an error is thrown instead of silently eating mis-specified configuration

<!-- Please describe the behavior or changes that are being added by this PR. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
