### PR TITLE
feat: support hostNetwork for Storage

### DIFF
--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -76,11 +76,11 @@ type StorageSpec struct {
 	// +optional
 	Monitoring *MonitoringOptions `json:"monitoring,omitempty"`
 
-  // Whether host network should be enabled. Automatically sets 
-  // `dnsPolicy` to `clusterFirstWithHostNet`.
-  // Default: false
-  // +optional
-  HostNetwork bool `json:"hostNetwork,omitempty"`
+	// Whether host network should be enabled. Automatically sets 
+	// `dnsPolicy` to `clusterFirstWithHostNet`.
+	// Default: false
+	// +optional
+	HostNetwork bool `json:"hostNetwork,omitempty"`
 
 	// NodeSelector is a selector which must be true for the pod to fit on a node.
 	// Selector which must match a node's labels for the pod to be scheduled on that node.

--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -76,6 +76,12 @@ type StorageSpec struct {
 	// +optional
 	Monitoring *MonitoringOptions `json:"monitoring,omitempty"`
 
+  // Whether host network should be enabled. Automatically sets 
+  // `dnsPolicy` to `clusterFirstWithHostNet`.
+  // Default: false
+  // +optional
+  HostNetwork bool `json:"hostNetwork,omitempty"`
+
 	// NodeSelector is a selector which must be true for the pod to fit on a node.
 	// Selector which must match a node's labels for the pod to be scheduled on that node.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/deploy/ydb-operator/crds/storage.yaml
+++ b/deploy/ydb-operator/crds/storage.yaml
@@ -1064,6 +1064,10 @@ spec:
                 - block-4-2
                 - none
                 type: string
+              hostNetwork:
+                description: 'Whether host network should be enabled. Automatically
+                  sets `dnsPolicy` to `clusterFirstWithHostNet`. Default: false'
+                type: boolean
               image:
                 description: Container image information
                 properties:

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -110,6 +110,11 @@ func (b *StorageStatefulSetBuilder) buildPodTemplateSpec() corev1.PodTemplateSpe
 			TopologySpreadConstraints: b.buildTopologySpreadConstraints(),
 		},
 	}
+
+  if b.Spec.HostNetwork {
+  	podTemplate.Spec.HostNetwork = true
+  	podTemplate.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
+  }
 	if b.Spec.Image.PullSecret != nil {
 		podTemplate.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: *b.Spec.Image.PullSecret}}
 	}

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -111,10 +111,10 @@ func (b *StorageStatefulSetBuilder) buildPodTemplateSpec() corev1.PodTemplateSpe
 		},
 	}
 
-  if b.Spec.HostNetwork {
-  	podTemplate.Spec.HostNetwork = true
-  	podTemplate.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
-  }
+	if b.Spec.HostNetwork {
+		podTemplate.Spec.HostNetwork = true
+		podTemplate.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
+	}
 	if b.Spec.Image.PullSecret != nil {
 		podTemplate.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: *b.Spec.Image.PullSecret}}
 	}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

No way to specify `hostNetwork` for Storage pods

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Possible to specify `hostNetwork` for Storage pods

<!-- Please describe the behavior or changes that are being added by this PR. -->

- use `hostNetwork: true` in Storage manifest, it would propagate `hostNetwork: true` and `dnsPolicy: clusterFirstWithHostNet` to actual Storage pods

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
