### PR TITLE
Support patching system trust store with custom CAs

### DIFF
--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -76,6 +76,12 @@ type StorageSpec struct {
 	// +optional
 	Monitoring *MonitoringOptions `json:"monitoring,omitempty"`
 
+	// User-defined root certificate authority that is added to system trust
+	// store of Storage pods on startup. 
+	// Default: ""
+	// +optional
+	CaBundle string `json:"caBundle,omitempty"`
+
 	// NodeSelector is a selector which must be true for the pod to fit on a node.
 	// Selector which must match a node's labels for the pod to be scheduled on that node.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -78,9 +78,8 @@ type StorageSpec struct {
 
 	// User-defined root certificate authority that is added to system trust
 	// store of Storage pods on startup. 
-	// Default: ""
 	// +optional
-	CaBundle string `json:"caBundle,omitempty"`
+	CABundle []byte `json:"caBundle,omitempty"`
 
 	// Whether host network should be enabled. Automatically sets 
 	// `dnsPolicy` to `clusterFirstWithHostNet`.

--- a/deploy/ydb-operator/crds/storage.yaml
+++ b/deploy/ydb-operator/crds/storage.yaml
@@ -881,6 +881,10 @@ spec:
                         type: array
                     type: object
                 type: object
+              caBundle:
+                description: 'User-defined root certificate authority that is added
+                  to system trust store of Storage pods on startup. Default: ""'
+                type: string
               configuration:
                 description: YDB configuration in YAML format. Will be applied on
                   top of generated one in internal/configuration

--- a/deploy/ydb-operator/crds/storage.yaml
+++ b/deploy/ydb-operator/crds/storage.yaml
@@ -882,8 +882,9 @@ spec:
                     type: object
                 type: object
               caBundle:
-                description: 'User-defined root certificate authority that is added
-                  to system trust store of Storage pods on startup. Default: ""'
+                description: User-defined root certificate authority that is added
+                  to system trust store of Storage pods on startup.
+                format: byte
                 type: string
               configuration:
                 description: YDB configuration in YAML format. Will be applied on

--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -11,6 +11,7 @@ import (
 type ConfigMapBuilder struct {
 	client.Object
 
+	Name   string
 	Data   map[string]string
 	Labels map[string]string
 }
@@ -35,7 +36,7 @@ func (b *ConfigMapBuilder) Build(obj client.Object) error {
 func (b *ConfigMapBuilder) Placeholder(cr client.Object) client.Object {
 	return &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.GetName(),
+			Name:      b.Name,
 			Namespace: cr.GetNamespace(),
 		},
 	}

--- a/internal/resources/database.go
+++ b/internal/resources/database.go
@@ -89,6 +89,7 @@ func (b *DatabaseBuilder) GetResourceBuilders() []ResourceBuilder {
 		optionalBuilders,
 		&ConfigMapBuilder{
 			Object: b,
+			Name: b.GetName(),
 			Data:   cfg,
 			Labels: databaseLabels,
 		},

--- a/internal/resources/resource.go
+++ b/internal/resources/resource.go
@@ -23,6 +23,17 @@ const (
 	interconnectTLSVolumeName = "interconnect-tls-volume"
 	datastreamsTLSVolumeName  = "datastreams-tls-volume"
 
+	initMainSharedCertsVolumeName = "init-main-shared-certs-volume"
+	initMainSharedSourceDirVolumeName = "init-main-shared-source-dir-volume"
+
+	caBundleVolumeName = "ca-bundle-volume"
+
+	caBundleConfigMap = "init-container-cert-auths"
+
+	defaultPathForLocalCerts = "/usr/local/share/ca-certificates"
+	temporaryPathForCertsInInit = "/etc/temporary-certs"
+	systemSslStorePath = "/etc/ssl/certs"
+
 	lastAppliedAnnotation                     = "ydb.tech/last-applied"
 	encryptionVolumeName                      = "encryption"
 	datastreamsIAMServiceAccountKeyVolumeName = "datastreams-iam-sa-key"

--- a/internal/resources/resource.go
+++ b/internal/resources/resource.go
@@ -23,16 +23,16 @@ const (
 	interconnectTLSVolumeName = "interconnect-tls-volume"
 	datastreamsTLSVolumeName  = "datastreams-tls-volume"
 
-	initMainSharedCertsVolumeName = "init-main-shared-certs-volume"
-	initMainSharedSourceDirVolumeName = "init-main-shared-source-dir-volume"
+	systemCertsVolumeName = "init-main-shared-certs-volume"
+	localCertsVolumeName = "init-main-shared-source-dir-volume"
 
 	caBundleVolumeName = "ca-bundle-volume"
 
 	caBundleConfigMap = "init-container-cert-auths"
 
-	defaultPathForLocalCerts = "/usr/local/share/ca-certificates"
-	temporaryPathForCertsInInit = "/etc/temporary-certs"
-	systemSslStorePath = "/etc/ssl/certs"
+	localCertsDir = "/usr/local/share/ca-certificates"
+	tmpCertsDir = "/etc/temporary-certs"
+	systemCertsDir = "/etc/ssl/certs"
 
 	lastAppliedAnnotation                     = "ydb.tech/last-applied"
 	encryptionVolumeName                      = "encryption"

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -62,6 +62,7 @@ func (b *StorageClusterBuilder) GetResourceBuilders() []ResourceBuilder {
 		optionalBuilders,
 		&ConfigMapBuilder{
 			Object: b,
+			Name:   b.Storage.GetName(),
 			Data:   cfg,
 			Labels: storageLabels,
 		},

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -46,9 +46,8 @@ func (b *StorageClusterBuilder) GetGRPCEndpoint() string {
 func (b *StorageClusterBuilder) appendCAConfigMapIfNeeded(optionalBuilders []ResourceBuilder) []ResourceBuilder {
 	additionalCAs := make(map[string]string)
 
-	if b.Spec.CaBundle != "" {
-		data, _ := base64.StdEncoding.DecodeString(b.Spec.CaBundle)
-		additionalCAs["generalRoot.crt"] = string(data)
+	if len(b.Spec.CABundle) > 0 {
+		additionalCAs["generalRoot.crt"] = string(b.Spec.CABundle)
 
 		optionalBuilders = append(
 			optionalBuilders,

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -51,15 +51,6 @@ func (b *StorageClusterBuilder) appendCAConfigMapIfNeeded(optionalBuilders []Res
 		additionalCAs["generalRoot.crt"] = string(data)
 	}
 
-	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
-		additionalCAs["grpcRoot.crt"] = DO SOMETHING
-	}
-
-	// TODO figure out how to get data from secret
-	// if b.Spec.Service.Interconnect.TLSConfiguration.Enabled {
-	// 	additionalCAs["interconnectRoot.crt"] = DO SOMETHING
-	// }
-
 	if len(additionalCAs) != 0 {
 		optionalBuilders = append(
 			optionalBuilders,

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	api "github.com/ydb-platform/ydb-kubernetes-operator/api/v1alpha1"
@@ -40,6 +41,38 @@ func (b *StorageClusterBuilder) GetGRPCEndpoint() string {
 		host = b.Spec.Service.GRPC.ExternalHost
 	}
 	return fmt.Sprintf("%s:%d", host, api.GRPCPort)
+}
+
+func (b *StorageClusterBuilder) appendCAConfigMapIfNeeded(optionalBuilders []ResourceBuilder) []ResourceBuilder {
+	additionalCAs := make(map[string]string)
+
+	if b.Spec.CaBundle != "" {
+		data, _ := base64.StdEncoding.DecodeString(b.Spec.CaBundle)
+		additionalCAs["generalRoot.crt"] = string(data)
+	}
+
+	// TODO figure out how to get data from secret
+	// if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
+	// 	additionalCAs["grpcRoot.crt"] = DO SOMETHING
+	// }
+
+	// TODO figure out how to get data from secret
+	// if b.Spec.Service.Interconnect.TLSConfiguration.Enabled {
+	// 	additionalCAs["interconnectRoot.crt"] = DO SOMETHING
+	// }
+
+	if len(additionalCAs) != 0 {
+		optionalBuilders = append(
+			optionalBuilders,
+			&ConfigMapBuilder{
+				Object: b,
+				Name:   caBundleConfigMap,
+				Data:   additionalCAs,
+			},
+		)
+	}
+
+	return optionalBuilders
 }
 
 func (b *StorageClusterBuilder) GetGRPCEndpointWithProto() string {
@@ -94,6 +127,8 @@ func (b *StorageClusterBuilder) GetResourceBuilders() []ResourceBuilder {
 			},
 		)
 	}
+
+	optionalBuilders = b.appendCAConfigMapIfNeeded(optionalBuilders)
 
 	return append(
 		optionalBuilders,

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -47,6 +47,8 @@ func (b *StorageClusterBuilder) appendCAConfigMapIfNeeded(optionalBuilders []Res
 	additionalCAs := make(map[string]string)
 
 	if len(b.Spec.CABundle) > 0 {
+		// According to OpenAPI V3 spec, CABundle here is already AUTOMATICALLY 
+		// decoded from base64 due to the type being `[]byte`.
 		additionalCAs["generalRoot.crt"] = string(b.Spec.CABundle)
 
 		optionalBuilders = append(

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -49,9 +49,7 @@ func (b *StorageClusterBuilder) appendCAConfigMapIfNeeded(optionalBuilders []Res
 	if b.Spec.CaBundle != "" {
 		data, _ := base64.StdEncoding.DecodeString(b.Spec.CaBundle)
 		additionalCAs["generalRoot.crt"] = string(data)
-	}
 
-	if len(additionalCAs) != 0 {
 		optionalBuilders = append(
 			optionalBuilders,
 			&ConfigMapBuilder{

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -51,10 +51,9 @@ func (b *StorageClusterBuilder) appendCAConfigMapIfNeeded(optionalBuilders []Res
 		additionalCAs["generalRoot.crt"] = string(data)
 	}
 
-	// TODO figure out how to get data from secret
-	// if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
-	// 	additionalCAs["grpcRoot.crt"] = DO SOMETHING
-	// }
+	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
+		additionalCAs["grpcRoot.crt"] = DO SOMETHING
+	}
 
 	// TODO figure out how to get data from secret
 	// if b.Spec.Service.Interconnect.TLSConfiguration.Enabled {

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -383,11 +383,11 @@ func (b *StorageStatefulSetBuilder) buildInitContainerArgs() ([]string, []string
 	}
 
 	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
-		arg += fmt.Sprintf("cp %s/* %s/", "/tls/grpc/ca.crt", defaultPathForLocalCerts) // fixme const
+		arg += fmt.Sprintf("cp /tls/grpc/ca.crt %s/", defaultPathForLocalCerts) // fixme const
 	}
 
 	if b.Spec.Service.Interconnect.TLSConfiguration.Enabled {
-		arg += fmt.Sprintf("cp %s/* %s/", "/tls/interconnect/ca.crt", defaultPathForLocalCerts) // fixme const
+		arg += fmt.Sprintf("cp /tls/interconnect/ca.crt %s/", defaultPathForLocalCerts) // fixme const
 	}
 
 	if arg != "" {

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -191,7 +191,7 @@ func (b *StorageStatefulSetBuilder) buildVolumes() []corev1.Volume {
 		})
 	}
 
-	if b.Spec.CaBundle != "" {
+	if len(b.Spec.CABundle) > 0 {
 		volumes = append(volumes, corev1.Volume{
 			Name: caBundleVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -227,7 +227,7 @@ func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainer() corev1.C
 }
 
 func (b *StorageStatefulSetBuilder) areAnyCertificatesAddedToStore() bool {
-	return b.Spec.CaBundle != "" ||
+	return len(b.Spec.CABundle) > 0 ||
 		b.Spec.Service.GRPC.TLSConfiguration.Enabled ||
 		b.Spec.Service.Interconnect.TLSConfiguration.Enabled
 }
@@ -247,7 +247,7 @@ func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainerVolumeMount
 		})
 	}
 
-	if b.Spec.CaBundle != "" {
+	if len(b.Spec.CABundle) > 0 {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      caBundleVolumeName,
 			ReadOnly:  true,
@@ -379,7 +379,7 @@ func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainerArgs() ([]s
 
 	arg := ""
 
-	if b.Spec.CaBundle != "" {
+	if len(b.Spec.CABundle) > 0 {
 		arg += fmt.Sprintf("cp %s/* %s/ && ", tmpCertsDir, localCertsDir)
 	}
 

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -379,11 +379,11 @@ func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainerArgs() ([]s
 	}
 
 	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
-		arg += fmt.Sprintf("cp /tls/grpc/ca.crt %s/", defaultPathForLocalCerts) // fixme const
+		arg += fmt.Sprintf("cp /tls/grpc/ca.crt %s/grpcRoot.crt", defaultPathForLocalCerts) // fixme const
 	}
 
 	if b.Spec.Service.Interconnect.TLSConfiguration.Enabled {
-		arg += fmt.Sprintf("cp /tls/interconnect/ca.crt %s/", defaultPathForLocalCerts) // fixme const
+		arg += fmt.Sprintf("cp /tls/interconnect/ca.crt %s/interconnectRoot.crt", defaultPathForLocalCerts) // fixme const
 	}
 
 	if arg != "" {

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -375,23 +375,19 @@ func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainerArgs() ([]s
 	arg := ""
 
 	if b.Spec.CaBundle != "" {
-		arg += fmt.Sprintf("cp %s/* %s/ &&", tmpCertsDir, localCertsDir)
+		arg += fmt.Sprintf("cp %s/* %s/ && ", tmpCertsDir, localCertsDir)
 	}
 
 	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
-		arg += fmt.Sprintf("cp /tls/grpc/ca.crt %s/grpcRoot.crt", localCertsDir) // fixme const
+		arg += fmt.Sprintf("cp /tls/grpc/ca.crt %s/grpcRoot.crt && ", localCertsDir) // fixme const
 	}
 
 	if b.Spec.Service.Interconnect.TLSConfiguration.Enabled {
-		arg += fmt.Sprintf("cp /tls/interconnect/ca.crt %s/interconnectRoot.crt", localCertsDir) // fixme const
+		arg += fmt.Sprintf("cp /tls/interconnect/ca.crt %s/interconnectRoot.crt && ", localCertsDir) // fixme const
 	}
 
 	if arg != "" {
-		arg += fmt.Sprintf("%s && %s && %s",
-			"apt-get update",
-			"apt-get install -y ca-certificates",
-			"update-ca-certificates",
-		)
+		arg += "update-ca-certificates"
 	}
 
 	args := []string{arg}

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -201,7 +201,7 @@ func (b *StorageStatefulSetBuilder) buildVolumes() []corev1.Volume {
 }
 
 func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainer() corev1.Container {
-	command, args := b.buildInitContainerArgs()
+	command, args := b.buildCaStorePatchingInitContainerArgs()
 
 	container := corev1.Container{
 		Name:            "ydb-storage-init-container",
@@ -214,7 +214,7 @@ func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainer() corev1.C
 			RunAsUser: new(int64),
 		},
 
-		VolumeMounts: b.buildInitContainerVolumeMounts(),
+		VolumeMounts: b.buildCaStorePatchingInitContainerVolumeMounts(),
 		Resources:    b.Spec.Resources,
 	}
 
@@ -227,7 +227,7 @@ func (b *StorageStatefulSetBuilder) areAnyCertificatesAddedToStore() bool {
 		b.Spec.Service.Interconnect.TLSConfiguration.Enabled
 }
 
-func (b *StorageStatefulSetBuilder) buildInitContainerVolumeMounts() []corev1.VolumeMount {
+func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainerVolumeMounts() []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{}
 
 	if b.areAnyCertificatesAddedToStore() {
@@ -369,7 +369,7 @@ func (b *StorageStatefulSetBuilder) buildVolumeMounts() []corev1.VolumeMount {
 	return volumeMounts
 }
 
-func (b *StorageStatefulSetBuilder) buildInitContainerArgs() ([]string, []string) {
+func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainerArgs() ([]string, []string) {
 	command := []string{"/bin/bash", "-c"}
 
 	arg := ""

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -97,7 +97,6 @@ func (b *StorageStatefulSetBuilder) buildPodTemplateSpec() corev1.PodTemplateSpe
 		},
 		Spec: corev1.PodSpec{
 			Containers:     []corev1.Container{b.buildContainer()},
-			InitContainers: b.Spec.InitContainers,
 			NodeSelector:   b.Spec.NodeSelector,
 			Affinity:       b.Spec.Affinity,
 			Tolerations:    b.Spec.Tolerations,
@@ -109,6 +108,22 @@ func (b *StorageStatefulSetBuilder) buildPodTemplateSpec() corev1.PodTemplateSpe
 			},
 			TopologySpreadConstraints: b.buildTopologySpreadConstraints(),
 		},
+	}
+
+	// InitContainer only needed for CaBundle manipulation for now,
+	// may be probably used for other stuff later
+	if b.Spec.CaBundle != "" {
+		podTemplate.Spec.InitContainers = append(
+			[]corev1.Container{b.buildInitContainer()},
+			b.Spec.InitContainers...,
+		)
+	} else {
+		podTemplate.Spec.InitContainers = b.Spec.InitContainers
+	}
+
+	if b.Spec.HostNetwork {
+		podTemplate.Spec.HostNetwork = true
+		podTemplate.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 	if b.Spec.Image.PullSecret != nil {
 		podTemplate.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: *b.Spec.Image.PullSecret}}
@@ -159,7 +174,74 @@ func (b *StorageStatefulSetBuilder) buildVolumes() []corev1.Volume {
 		volumes = append(volumes, buildTLSVolume(interconnectTLSVolumeName, b.Spec.Service.Interconnect.TLSConfiguration))
 	}
 
+	if b.Spec.CaBundle != "" {
+		volumes = append(volumes, corev1.Volume{
+			Name: initMainSharedCertsVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		})
+
+		volumes = append(volumes, corev1.Volume{
+			Name: initMainSharedSourceDirVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		})
+
+		volumes = append(volumes, corev1.Volume{
+			Name: caBundleVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: caBundleConfigMap},
+				},
+			},
+		})
+	}
+
 	return volumes
+}
+
+func (b *StorageStatefulSetBuilder) buildInitContainer() corev1.Container {
+	command, args := b.buildInitContainerArgs()
+
+	container := corev1.Container{
+		Name:            "ydb-storage-init-container",
+		Image:           b.Spec.Image.Name,
+		ImagePullPolicy: *b.Spec.Image.PullPolicyName,
+		Command:         command,
+		Args:            args,
+
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser: new(int64),
+		},
+
+		VolumeMounts: b.buildInitContainerVolumeMounts(),
+		Resources:    b.Spec.Resources,
+	}
+
+	return container
+}
+
+func (b *StorageStatefulSetBuilder) buildInitContainerVolumeMounts() []corev1.VolumeMount {
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      caBundleVolumeName,
+			MountPath: temporaryPathForCertsInInit,
+		},
+	}
+
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      initMainSharedCertsVolumeName,
+		MountPath: systemSslStorePath,
+	})
+
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      initMainSharedSourceDirVolumeName,
+		MountPath: defaultPathForLocalCerts,
+	})
+
+	return volumeMounts
 }
 
 func (b *StorageStatefulSetBuilder) buildContainer() corev1.Container { // todo add init container for sparse files?
@@ -248,7 +330,34 @@ func (b *StorageStatefulSetBuilder) buildVolumeMounts() []corev1.VolumeMount {
 		})
 	}
 
+	if b.Spec.CaBundle != "" {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      initMainSharedCertsVolumeName,
+			ReadOnly:  true,
+			MountPath: systemSslStorePath,
+		})
+
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      initMainSharedSourceDirVolumeName,
+			ReadOnly:  true,
+			MountPath: defaultPathForLocalCerts,
+		})
+	}
+
 	return volumeMounts
+}
+
+func (b *StorageStatefulSetBuilder) buildInitContainerArgs() ([]string, []string) {
+	command := []string{"/bin/bash", "-c"}
+
+	args := []string{fmt.Sprintf("%s && %s && %s && %s",
+		fmt.Sprintf("cp %s/* %s/", temporaryPathForCertsInInit, defaultPathForLocalCerts),
+		"apt-get update",
+		"apt-get install -y ca-certificates",
+		"update-ca-certificates",
+	)}
+
+	return command, args
 }
 
 func (b *StorageStatefulSetBuilder) buildContainerArgs() ([]string, []string) {

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -172,14 +172,14 @@ func (b *StorageStatefulSetBuilder) buildVolumes() []corev1.Volume {
 
 	if b.areAnyCertificatesAddedToStore() {
 		volumes = append(volumes, corev1.Volume{
-			Name: initMainSharedCertsVolumeName,
+			Name: systemCertsVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		})
 
 		volumes = append(volumes, corev1.Volume{
-			Name: initMainSharedSourceDirVolumeName,
+			Name: localCertsVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -232,13 +232,13 @@ func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainerVolumeMount
 
 	if b.areAnyCertificatesAddedToStore() {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      initMainSharedSourceDirVolumeName,
-			MountPath: defaultPathForLocalCerts,
+			Name:      localCertsVolumeName,
+			MountPath: localCertsDir,
 		})
 
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      initMainSharedCertsVolumeName,
-			MountPath: systemSslStorePath,
+			Name:      systemCertsVolumeName,
+			MountPath: systemCertsDir,
 		})
 	}
 
@@ -246,7 +246,7 @@ func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainerVolumeMount
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      caBundleVolumeName,
 			ReadOnly:  true,
-			MountPath: temporaryPathForCertsInInit,
+			MountPath: tmpCertsDir,
 		})
 	}
 
@@ -356,13 +356,13 @@ func (b *StorageStatefulSetBuilder) buildVolumeMounts() []corev1.VolumeMount {
 
 	if b.areAnyCertificatesAddedToStore() {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      initMainSharedSourceDirVolumeName,
-			MountPath: defaultPathForLocalCerts,
+			Name:      localCertsVolumeName,
+			MountPath: localCertsDir,
 		})
 
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      initMainSharedCertsVolumeName,
-			MountPath: systemSslStorePath,
+			Name:      systemCertsVolumeName,
+			MountPath: systemCertsDir,
 		})
 	}
 
@@ -375,15 +375,15 @@ func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainerArgs() ([]s
 	arg := ""
 
 	if b.Spec.CaBundle != "" {
-		arg += fmt.Sprintf("cp %s/* %s/ &&", temporaryPathForCertsInInit, defaultPathForLocalCerts)
+		arg += fmt.Sprintf("cp %s/* %s/ &&", tmpCertsDir, localCertsDir)
 	}
 
 	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
-		arg += fmt.Sprintf("cp /tls/grpc/ca.crt %s/grpcRoot.crt", defaultPathForLocalCerts) // fixme const
+		arg += fmt.Sprintf("cp /tls/grpc/ca.crt %s/grpcRoot.crt", localCertsDir) // fixme const
 	}
 
 	if b.Spec.Service.Interconnect.TLSConfiguration.Enabled {
-		arg += fmt.Sprintf("cp /tls/interconnect/ca.crt %s/interconnectRoot.crt", defaultPathForLocalCerts) // fixme const
+		arg += fmt.Sprintf("cp /tls/interconnect/ca.crt %s/interconnectRoot.crt", localCertsDir) // fixme const
 	}
 
 	if arg != "" {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

There is no way to add custom CA certificates to pod's system trust store. CA from tls configuration of GRPC and Interconnect services are also not added to pod's system trust store.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: YDBOPS-6073

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- a new optional `caBundle` field in Storage specification, accepting raw base64-encoded CA certificate data
- CA from `spec.service.[interconnect|grpc].certificateAuthority` are also added to system trust store

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

- it is also now possible to specify names of ConfigMaps, when using custom ResourceBuilders. Therefore, more than one ConfigMap can be created for one custom resource (e.g. Storage) at the same time. 
