### PR TITLE
Enable privileged for tmp testing with Filesystem mode

### DIFF
--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -185,7 +185,7 @@ func (b *StorageStatefulSetBuilder) buildContainer() corev1.Container { // todo 
 		},
 
 		SecurityContext: &corev1.SecurityContext{
-			Privileged: ptr.Bool(false),
+			Privileged: ptr.Bool(true),
 		},
 
 		Ports: []corev1.ContainerPort{{


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?

- unable to access disks when volumes with `volumeMode: Filesystem` are mounted, due to the lack of privileges

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- volumes should mount with `Filesystem` volumeMode

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
