### PR TITLE
Stub for `blobstorage init`

### DIFF
--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	api "github.com/ydb-platform/ydb-kubernetes-operator/api/v1alpha1"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: YDBOPS-6244

Even if the Storage had been initialized already, ydb-operator is unable to detect it and retries to initialize storage until the end of time.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- operator is capable of identifying whether storage has already been initialized
- a build bug has been fixed, one of the previous PRs had an unused dependency on `encoding/base64`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
