### PR TITLE
chore: refactor chart naming, introduce nodeSelector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # YDB Kubernetes Operator
 
-The YDB Kubernetes operator deploys and manages YDB resources on a Kubernetes cluster.
+The YDB Kubernetes operator deploys and manages YDB resources in a Kubernetes cluster.
 
 ## Prerequisites
 
@@ -15,7 +15,7 @@ The YDB Kubernetes operator deploys and manages YDB resources on a Kubernetes cl
 
 ## Usage
 
-For steps how to deploy and use YDB Kubernetes Operator, please refer to [documentation](https://ydb.tech/en/docs/deploy/orchestrated/concepts).
+For steps on how to deploy and use YDB Kubernetes Operator, please refer to [documentation](https://ydb.tech/en/docs/deploy/orchestrated/concepts).
 
 ## Development
 

--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.11
+version: 0.4.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.11"
+appVersion: "0.4.12"

--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: operator
-description: A Helm chart for Kubernetes
+name: ydb-operator
+description: A Helm chart for deploying YDB Kubernetes operator.
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.9
+version: 0.4.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.12"
+appVersion: "0.4.11"

--- a/deploy/ydb-operator/templates/deployment.yaml
+++ b/deploy/ydb-operator/templates/deployment.yaml
@@ -15,8 +15,10 @@ spec:
       labels:
         {{- include "ydb.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- .Values.nodeSelector | nindent 8 }}
+        {{- toYaml . | nindent 8 -}}
+      {{- end }}
       containers:
         - args:
             - --health-probe-bind-address=:8081
@@ -30,8 +32,13 @@ spec:
             {{- end }}
           command:
             - /manager
-          image: {{ .Values.image.repository }}:{{ eq .Values.image.tag "REPLACED_BY_CHART_VERSION_IF_UNSPECIFIED" }}{{ $.Chart.Version }}{{ else }}{{ .Values.image.tag }}{{ end }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ default "cr.yandex/yc/ydb-kubernetes-operator" .Values.image.repository }}:
+            {{- if eq .Values.image.tag "REPLACED_BY_CHART_APP_VERSION_IF_UNSPECIFIED" -}}
+              {{- .Chart.AppVersion -}}
+            {{- else -}}
+              {{- .Values.image.tag -}}
+            {{- end }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/ydb-operator/templates/deployment.yaml
+++ b/deploy/ydb-operator/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         {{- include "ydb.selectorLabels" . | nindent 8 }}
     spec:
+      nodeSelector:
+        {{- .Values.nodeSelector | nindent 8 }}
       containers:
         - args:
             - --health-probe-bind-address=:8081
@@ -28,7 +30,7 @@ spec:
             {{- end }}
           command:
             - /manager
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ .Values.image.repository }}:{{ eq .Values.image.tag "REPLACED_BY_CHART_VERSION_IF_UNSPECIFIED" }}{{ $.Chart.Version }}{{ else }}{{ .Values.image.tag }}{{ end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             httpGet:

--- a/deploy/ydb-operator/values.yaml
+++ b/deploy/ydb-operator/values.yaml
@@ -6,7 +6,7 @@ image:
   ##
   pullPolicy: IfNotPresent
   repository: cr.yandex/yc/ydb-kubernetes-operator
-  tag: 0.4.12
+  tag: "REPLACED_BY_CHART_VERSION_IF_NOT_PRESENT"
 
 ## Secrets to use for Docker registry access
 ## Secrets must be provided manually.
@@ -16,6 +16,8 @@ image:
 ##   - myRegistryKeySecretName
 ##
 imagePullSecrets: []
+
+nodeSelector: {}
 
 nameOverride: ""
 fullnameOverride: ""

--- a/deploy/ydb-operator/values.yaml
+++ b/deploy/ydb-operator/values.yaml
@@ -6,7 +6,7 @@ image:
   ##
   pullPolicy: IfNotPresent
   repository: cr.yandex/yc/ydb-kubernetes-operator
-  tag: "REPLACED_BY_CHART_VERSION_IF_NOT_PRESENT"
+  tag: "REPLACED_BY_CHART_APP_VERSION_IF_UNSPECIFIED"
 
 ## Secrets to use for Docker registry access
 ## Secrets must be provided manually.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

Refactoring the chart to bring some quality of life improvements

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- helm chart is now called `ydb-operator`
- operator tag is determined from Chart `appVersion` when not specified explicitly
- it is now possible to specify `nodeSelector` for operator's Deployment

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
