### PR TITLE
Additional secrets (YDB-6448)

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -23,7 +23,7 @@ const (
 	DiskPathPrefix      = "/dev/kikimr_ssd"
 	DiskNumberMaxDigits = 2
 	DiskFilePath        = "/data"
-	YdbAuthToken = "ydb-auth-token-file"
+	YdbAuthToken        = "ydb-auth-token-file"
 
 	ConfigDir      = "/opt/ydb/cfg"
 	ConfigFileName = "config.yaml"

--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -23,6 +23,7 @@ const (
 	DiskPathPrefix      = "/dev/kikimr_ssd"
 	DiskNumberMaxDigits = 2
 	DiskFilePath        = "/data"
+	YdbAuthToken = "ydb-auth-token-file"
 
 	ConfigDir      = "/opt/ydb/cfg"
 	ConfigFileName = "config.yaml"

--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -81,7 +81,7 @@ type StorageSpec struct {
 	// +optional
 	CABundle []byte `json:"caBundle,omitempty"`
 
-	// Additional secret names that will be mounted into the well-known directory of 
+	// Additional secret names that will be mounted into the well-known directory of
 	// every storage pod. Directory: `/opt/ydb/secrets/<secret_name>/<secret_key>`
 	// +optional
 	AdditionalSecrets []*corev1.LocalObjectReference `json:"additionalSecrets,omitempty"`

--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -84,7 +84,7 @@ type StorageSpec struct {
 	// Additional secret names that will be mounted into the well-known directory of 
 	// every storage pod. Directory: `/opt/ydb/secrets/<secret_name>/<secret_key>`
 	// +optional
-	Secrets []*corev1.LocalObjectReference `json:"secrets,omitempty"`
+	AdditionalSecrets []*corev1.LocalObjectReference `json:"secrets,omitempty"`
 
 	// Whether host network should be enabled. Automatically sets
 	// `dnsPolicy` to `clusterFirstWithHostNet`.

--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -81,10 +81,10 @@ type StorageSpec struct {
 	// +optional
 	CABundle []byte `json:"caBundle,omitempty"`
 
-	// Additional secret names that will be mounted into the well-known directory of
+	// Secret names that will be mounted into the well-known directory of
 	// every storage pod. Directory: `/opt/ydb/secrets/<secret_name>/<secret_key>`
 	// +optional
-	AdditionalSecrets []*corev1.LocalObjectReference `json:"additionalSecrets,omitempty"`
+	Secrets []*corev1.LocalObjectReference `json:"secrets,omitempty"`
 
 	// Whether host network should be enabled. Automatically sets
 	// `dnsPolicy` to `clusterFirstWithHostNet`.

--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -81,6 +81,11 @@ type StorageSpec struct {
 	// +optional
 	CABundle []byte `json:"caBundle,omitempty"`
 
+	// Additional secret names that will be mounted into the well-known directory of 
+	// every storage pod. Directory: `/opt/ydb/secrets/<secret_name>/<secret_key>`
+	// +optional
+	Secrets []*corev1.LocalObjectReference `json:"secrets,omitempty"`
+
 	// Whether host network should be enabled. Automatically sets
 	// `dnsPolicy` to `clusterFirstWithHostNet`.
 	// Default: false

--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -84,7 +84,7 @@ type StorageSpec struct {
 	// Additional secret names that will be mounted into the well-known directory of 
 	// every storage pod. Directory: `/opt/ydb/secrets/<secret_name>/<secret_key>`
 	// +optional
-	AdditionalSecrets []*corev1.LocalObjectReference `json:"secrets,omitempty"`
+	AdditionalSecrets []*corev1.LocalObjectReference `json:"additionalSecrets,omitempty"`
 
 	// Whether host network should be enabled. Automatically sets
 	// `dnsPolicy` to `clusterFirstWithHostNet`.

--- a/api/v1alpha1/storage_webhook.go
+++ b/api/v1alpha1/storage_webhook.go
@@ -5,6 +5,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/strings/slices"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -74,6 +75,17 @@ func (r *Storage) ValidateCreate() error {
 
 	if r.Spec.Nodes < minNodesPerErasure[r.Spec.Erasure] {
 		return fmt.Errorf("erasure type %v requires at least %v storage nodes", r.Spec.Erasure, minNodesPerErasure[r.Spec.Erasure])
+	}
+
+	reservedSecretNames := []string{
+		"database_encryption",
+		"datastreams",
+	}
+
+	for _, secret := range r.Spec.Secrets {
+		if slices.Contains(reservedSecretNames, secret.Name) {
+			return fmt.Errorf("the secret name %s is reserved, use another one", secret.Name)
+		}
 	}
 
 	// TODO(user): fill in your validation logic upon object creation.

--- a/deploy/ydb-operator/crds/storage.yaml
+++ b/deploy/ydb-operator/crds/storage.yaml
@@ -56,6 +56,19 @@ spec:
                 description: (Optional) Additional custom resource labels that are
                   added to all resources
                 type: object
+              additionalSecrets:
+                description: 'Additional secret names that will be mounted into the
+                  well-known directory of every storage pod. Directory: `/opt/ydb/secrets/<secret_name>/<secret_key>`'
+                items:
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                type: array
               affinity:
                 description: (Optional) If specified, the pod's scheduling constraints
                 properties:

--- a/deploy/ydb-operator/crds/storage.yaml
+++ b/deploy/ydb-operator/crds/storage.yaml
@@ -56,19 +56,6 @@ spec:
                 description: (Optional) Additional custom resource labels that are
                   added to all resources
                 type: object
-              additionalSecrets:
-                description: 'Additional secret names that will be mounted into the
-                  well-known directory of every storage pod. Directory: `/opt/ydb/secrets/<secret_name>/<secret_key>`'
-                items:
-                  description: LocalObjectReference contains enough information to
-                    let you locate the referenced object inside the same namespace.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                type: array
               affinity:
                 description: (Optional) If specified, the pod's scheduling constraints
                 properties:
@@ -2367,6 +2354,19 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              secrets:
+                description: 'Secret names that will be mounted into the well-known
+                  directory of every storage pod. Directory: `/opt/ydb/secrets/<secret_name>/<secret_key>`'
+                items:
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                type: array
               service:
                 description: '(Optional) Storage services parameter overrides Default:
                   (not specified)'

--- a/internal/controllers/storage/sync.go
+++ b/internal/controllers/storage/sync.go
@@ -173,7 +173,7 @@ func (r *Reconciler) handleResourcesSync(
 ) (bool, ctrl.Result, error) {
 	r.Log.Info("running step handleResourcesSync")
 
-	for _, builder := range storage.GetResourceBuilders() {
+	for _, builder := range storage.GetResourceBuilders(r.Config) {
 		newResource := builder.Placeholder(storage)
 
 		result, err := resources.CreateOrUpdateIgnoreStatus(ctx, r.Client, newResource, func() error {

--- a/internal/resources/resource.go
+++ b/internal/resources/resource.go
@@ -26,6 +26,9 @@ const (
 	systemCertsVolumeName = "init-main-shared-certs-volume"
 	localCertsVolumeName  = "init-main-shared-source-dir-volume"
 
+	wellKnownDirForAdditionalSecrets = "/opt/ydb/secrets"
+	additionalSecretVolumeName = "additional-secret-volume"
+
 	caBundleVolumeName = "ca-bundle-volume"
 
 	caBundleConfigMap = "init-container-cert-auths"

--- a/internal/resources/resource.go
+++ b/internal/resources/resource.go
@@ -27,7 +27,6 @@ const (
 	localCertsVolumeName  = "init-main-shared-source-dir-volume"
 
 	wellKnownDirForAdditionalSecrets = "/opt/ydb/secrets"
-	additionalSecretVolumeName = "additional-secret-volume"
 
 	caBundleVolumeName = "ca-bundle-volume"
 

--- a/internal/resources/secret.go
+++ b/internal/resources/secret.go
@@ -1,0 +1,37 @@
+package resources
+
+import (
+	"context"
+	"log"
+
+	"errors"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func checkSecretHasField(namespace string, secretName string, secretField string, config *rest.Config) (bool, error) {
+  log.Printf("checking if secret %s has field %s...\n", secretName, secretField)
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return false, errors.New("failed to create kubernetes clientset")
+	}
+
+	req, err := clientset.
+		CoreV1().
+		Secrets(namespace).
+		Get(context.TODO(), secretName, v1.GetOptions{})
+
+	log.Print("Secret getting req: ", req)
+	log.Print("Secret getting err: ", err)
+
+	if err != nil {
+		return false, err
+	}
+
+	_, exists := req.Data[secretField]
+
+	return exists, nil
+}

--- a/internal/resources/secret.go
+++ b/internal/resources/secret.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"log"
 
 	"errors"
 
@@ -11,9 +10,12 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func checkSecretHasField(namespace string, secretName string, secretField string, config *rest.Config) (bool, error) {
-  log.Printf("checking if secret %s has field %s...\n", secretName, secretField)
-
+func checkSecretHasField(
+	namespace string,
+	secretName string,
+	secretField string,
+	config *rest.Config,
+) (bool, error) {
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return false, errors.New("failed to create kubernetes clientset")
@@ -23,9 +25,6 @@ func checkSecretHasField(namespace string, secretName string, secretField string
 		CoreV1().
 		Secrets(namespace).
 		Get(context.TODO(), secretName, v1.GetOptions{})
-
-	log.Print("Secret getting req: ", req)
-	log.Print("Secret getting err: ", err)
 
 	if err != nil {
 		return false, err

--- a/internal/resources/secret.go
+++ b/internal/resources/secret.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-
 	"errors"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -165,7 +165,7 @@ func (b *StorageClusterBuilder) GetResourceBuilders(restConfig *rest.Config) []R
 		&StorageStatefulSetBuilder{
 			Storage: b.Unwrap(),
 			Labels:  storageLabels,
-			Config: restConfig,
+			RestConfig: restConfig,
 		},
 	)
 }

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -163,8 +163,8 @@ func (b *StorageClusterBuilder) GetResourceBuilders(restConfig *rest.Config) []R
 			IPFamilyPolicy: b.Spec.Service.Status.IPFamilyPolicy,
 		},
 		&StorageStatefulSetBuilder{
-			Storage: b.Unwrap(),
-			Labels:  storageLabels,
+			Storage:    b.Unwrap(),
+			Labels:     storageLabels,
 			RestConfig: restConfig,
 		},
 	)

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -5,6 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 
 	api "github.com/ydb-platform/ydb-kubernetes-operator/api/v1alpha1"
 	"github.com/ydb-platform/ydb-kubernetes-operator/internal/configuration"
@@ -73,7 +74,7 @@ func (b *StorageClusterBuilder) GetGRPCEndpointWithProto() string {
 	return fmt.Sprintf("%s%s", proto, b.GetGRPCEndpoint())
 }
 
-func (b *StorageClusterBuilder) GetResourceBuilders() []ResourceBuilder {
+func (b *StorageClusterBuilder) GetResourceBuilders(restConfig *rest.Config) []ResourceBuilder {
 	storageLabels := labels.StorageLabels(b.Unwrap())
 
 	var optionalBuilders []ResourceBuilder
@@ -164,6 +165,7 @@ func (b *StorageClusterBuilder) GetResourceBuilders() []ResourceBuilder {
 		&StorageStatefulSetBuilder{
 			Storage: b.Unwrap(),
 			Labels:  storageLabels,
+			Config: restConfig,
 		},
 	)
 }

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -178,7 +178,7 @@ func (b *StorageStatefulSetBuilder) buildVolumes() []corev1.Volume {
 		volumes = append(volumes, buildTLSVolume(interconnectTLSVolumeName, b.Spec.Service.Interconnect.TLSConfiguration))
 	}
 
-	for _, secret := range b.Spec.Secrets {
+	for _, secret := range b.Spec.AdditionalSecrets {
 		volumes = append(volumes, corev1.Volume{
 			Name: secret.Name,
 			VolumeSource: corev1.VolumeSource{
@@ -385,7 +385,7 @@ func (b *StorageStatefulSetBuilder) buildVolumeMounts() []corev1.VolumeMount {
 		})
 	}
 
-	for _, secret := range b.Spec.Secrets {
+	for _, secret := range b.Spec.AdditionalSecrets {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      secret.Name,
 			MountPath: fmt.Sprintf("%s/%s", wellKnownDirForAdditionalSecrets, secret.Name),
@@ -441,7 +441,7 @@ func (b *StorageStatefulSetBuilder) buildContainerArgs() ([]string, []string) {
 		"static",
 	)
 
-	for _, secret := range b.Spec.Secrets {
+	for _, secret := range b.Spec.AdditionalSecrets {
 		if exists, _ := checkSecretHasField(b.GetNamespace(), secret.Name, v1alpha1.YdbAuthToken, b.RestConfig); exists {
 			args = append(args,
 				"--auth-token-file",

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -179,7 +179,7 @@ func (b *StorageStatefulSetBuilder) buildVolumes() []corev1.Volume {
 		volumes = append(volumes, buildTLSVolume(interconnectTLSVolumeName, b.Spec.Service.Interconnect.TLSConfiguration))
 	}
 
-	for _, secret := range b.Spec.AdditionalSecrets {
+	for _, secret := range b.Spec.Secrets {
 		volumes = append(volumes, corev1.Volume{
 			Name: secret.Name,
 			VolumeSource: corev1.VolumeSource{
@@ -386,7 +386,7 @@ func (b *StorageStatefulSetBuilder) buildVolumeMounts() []corev1.VolumeMount {
 		})
 	}
 
-	for _, secret := range b.Spec.AdditionalSecrets {
+	for _, secret := range b.Spec.Secrets {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      secret.Name,
 			MountPath: fmt.Sprintf("%s/%s", wellKnownDirForAdditionalSecrets, secret.Name),
@@ -442,7 +442,7 @@ func (b *StorageStatefulSetBuilder) buildContainerArgs() ([]string, []string) {
 		"static",
 	)
 
-	for _, secret := range b.Spec.AdditionalSecrets {
+	for _, secret := range b.Spec.Secrets {
 		exists, err := checkSecretHasField(
 			b.GetNamespace(),
 			secret.Name,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Not possible to supply secrets to YDB Storage pods

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Possible to supply additional secrets to YDB using `additionalSecrets` field in CRD.

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `additionalSecrets` is a list of references to secrets:
```
additionalSecrets:
- name: my-secret-1
- name: my-secret-2
```
- each secret will get all its keys mounted as files into a well-known non-configurable directory like this `/opt/ydb/secrets/<secret-name>/<secret-key>`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
