### PR TITLE
Use Env instead of ConfigMap to transfer user CABundle to init container

### DIFF
--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.13
+version: 0.4.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.13"
+appVersion: "0.4.14"

--- a/internal/resources/resource.go
+++ b/internal/resources/resource.go
@@ -28,9 +28,8 @@ const (
 
 	wellKnownDirForAdditionalSecrets = "/opt/ydb/secrets"
 
-	caBundleVolumeName = "ca-bundle-volume"
-
-	caBundleConfigMap = "init-container-cert-auths"
+	caBundleEnvName  = "CA_BUNDLE"
+	caBundleFileName = "userCABundle.crt"
 
 	localCertsDir  = "/usr/local/share/ca-certificates"
 	tmpCertsDir    = "/etc/temporary-certs"

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -44,27 +44,6 @@ func (b *StorageClusterBuilder) GetGRPCEndpoint() string {
 	return fmt.Sprintf("%s:%d", host, api.GRPCPort)
 }
 
-func (b *StorageClusterBuilder) appendCAConfigMapIfNeeded(optionalBuilders []ResourceBuilder) []ResourceBuilder {
-	additionalCAs := make(map[string]string)
-
-	if len(b.Spec.CABundle) > 0 {
-		// According to OpenAPI V3 spec, CABundle here is already AUTOMATICALLY
-		// decoded from base64 due to the type being `[]byte`.
-		additionalCAs["generalRoot.crt"] = string(b.Spec.CABundle)
-
-		optionalBuilders = append(
-			optionalBuilders,
-			&ConfigMapBuilder{
-				Object: b,
-				Name:   caBundleConfigMap,
-				Data:   additionalCAs,
-			},
-		)
-	}
-
-	return optionalBuilders
-}
-
 func (b *StorageClusterBuilder) GetGRPCEndpointWithProto() string {
 	proto := api.GRPCProto
 	if b.Spec.Service.GRPC.TLSConfiguration != nil && b.Spec.Service.GRPC.TLSConfiguration.Enabled {
@@ -117,9 +96,6 @@ func (b *StorageClusterBuilder) GetResourceBuilders(restConfig *rest.Config) []R
 			},
 		)
 	}
-
-	optionalBuilders = b.appendCAConfigMapIfNeeded(optionalBuilders)
-
 	return append(
 		optionalBuilders,
 		&ServiceBuilder{


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Old behavior used single name for all storage objects which led to conficts.
- New behavior uses env CA_BUNDLE to copy Storage.Spec.CABundle to init container.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
