### PR TITLE
fix: bring alpine image back for well-known CAs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ jobs:
           disk-size: 465GB
           memory: 32GB
           core-fraction: 100
-          subnet-id: e9bm73bk6gh9ag8clm2o
+          subnet-id: e9bu12i8ocv6q8kl83ru
   run-e2e-job:
     name: run-e2e-job
     needs: start-runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY internal/ internal/
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/ydb-kubernetes-operator/main.go
 
-FROM scratch
+FROM alpine:3.15
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.19
+version: 0.4.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.19"
+appVersion: "0.4.20"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Revert base image change `alpine -> scratch`. It was done earlier to save space, but this gain is really negligible - 54mb on alpine vs 50mb on scratch. However, alpine image contains some well-known CAs which are important for TLS communication with `Storage`.

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
