### PR TITLE
fix: typo in autotagging pipeline not triggering build

### DIFF
--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -23,7 +23,7 @@ jobs:
         regex_pattern: 'version:[\s]*(["]?[0-9\.]{3,}["]?)'
   upload-artifacts:
     runs-on: ubuntu-latest
-    needs: tag
+    needs: tag-job
     if: ${{ needs.tag-job.outputs.tagcreated == 'yes' }}
     steps:
     - uses: actions/checkout@v2          


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

The pipeline of building artifacts isn't able to run because of a typo

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):