### PR TITLE
fix: register monitoringv1 in scheme

### DIFF
--- a/cmd/ydb-kubernetes-operator/main.go
+++ b/cmd/ydb-kubernetes-operator/main.go
@@ -25,6 +25,7 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 
 	utilruntime.Must(ydbv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme


### PR DESCRIPTION
Fix "no kind is registered for the type v1.ServiceMonitor in scheme" error.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behavior?

```
2023-04-07T00:14:54Z    ERROR   Reconciler error        {"controller": "database", "controllerGroup": "ydb.tech", "controllerKind": "Database", "Database": {"name":"db","namespace":"ydb"}, "namespace": "ydb", "name": "db", "reconcileID": "e40e2325-b14a-4df5-a327-13e504390fc6", "error": "no kind is registered for the type v1.ServiceMonitor in scheme \"pkg/runtime/scheme.go:100\""}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:329
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:274
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:235
2023-04-07T00:14:54Z    DEBUG   events  Resource: *v1.ServiceMonitor, Namespace: ydb, Name: db, failed to sync, error: no kind is registered for the type v1.ServiceMonitor in scheme "pkg/runtime/scheme.go:100"       {"type": "Warning", "object": {"kind":"Database","namespace":"ydb","name":"db","uid":"1fb59d84-d1d9-4d58-86b7-cfdb08483467","apiVersion":"ydb.tech/v1alpha1","resourceVersion":"5394989"}, "reason": "ProvisioningFailed"}
```
Issue Number: N/A

## What is the new behavior?

Error is fixed.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
