### PR TITLE
feat: introduce a crutch job to allow external contributions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,11 +1,20 @@
+# Implicit requirements
+# runner must have `docker` and `curl` installed (true on github-runners)
+
 name: run-tests
 on:
-  pull_request:
-    branches: [ "master" ]
+  workflow_run:
+    workflows: ["waiter-for-approval"]
+    types:
+      - completed
 jobs:
   start-runner:
     name: start-self-hosted-yc-runner
     runs-on: ubuntu-latest
+    needs: waiter-for-approval
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     outputs:
       label: ${{ steps.start-yc-runner.outputs.label }}
       instance-id: ${{ steps.start-yc-runner.outputs.instance-id }}

--- a/.github/workflows/waiter-for-approval.yml
+++ b/.github/workflows/waiter-for-approval.yml
@@ -6,7 +6,7 @@ jobs:
   waiter-for-approval:
     runs-on: ubuntu-latest
     steps:
-      - name: run
+      - name: What does this job even do?
         run: |
           echo "This job was either triggered by maintainer's pull request or explicitly allowed to run by maintainers."
           echo "This means that another job, e2e.yml, with access to secrets will run shortly."

--- a/.github/workflows/waiter-for-approval.yml
+++ b/.github/workflows/waiter-for-approval.yml
@@ -1,0 +1,13 @@
+name: waiter-for-approval
+on:
+  pull_request:
+    branches: [ "master" ]
+jobs:
+  waiter-for-approval:
+    runs-on: ubuntu-latest
+    steps:
+      - name: run
+        run: |
+          echo "This job was either triggered by maintainer's pull request or explicitly allowed to run by maintainers."
+          echo "This means that another job, e2e.yml, with access to secrets will run shortly."
+          echo "Secrets are necessary to create an external runner in Y.Cloud that is powerful enough to run tests."


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- This is a housekeeping PR to resolve some Github-related issues. Now, whenever an outside collaborator opens a PR, it is not launched until approved by one of the maintainers. After that, a job that does testing is triggered which has access to repository secrets. For maintainers themselves, the approval is not required and the testing job starts automatically.