### PR TITLE
unique webhookPathPrefix with fqdn url usage

### DIFF
--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.27
+version: 0.4.28
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/ydb-operator/templates/_helpers.tpl
+++ b/deploy/ydb-operator/templates/_helpers.tpl
@@ -52,11 +52,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 
 {{/*
-Create webhooks pathPrefix when fqdn url being used
+Create webhooks pathPrefix used by service fqdn url
 */}}
 {{- define "ydb.webhookPathPrefix" -}}
-{{- default "" .Values.webhook.service.pathPrefix -}}
-{{- if and .Values.webhook.service.pathPrefix (kindIs "bool" .Values.webhook.service.pathPrefix) -}}
+{{- if .Values.webhook.service.enableDefaultPathPrefix -}}
 {{- printf "/%s/%s" .Release.Namespace ( include "ydb.fullname" . ) -}}
 {{- end }}
+{{- if .Values.webhook.service.customPathPrefix -}}
+{{- .Values.webhook.service.customPathPrefix -}}
 {{- end }}
+{{- end -}}

--- a/deploy/ydb-operator/templates/_helpers.tpl
+++ b/deploy/ydb-operator/templates/_helpers.tpl
@@ -49,3 +49,14 @@ Selector labels
 app.kubernetes.io/name: {{ include "ydb.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+
+{{/*
+Create webhooks pathPrefix when fqdn url being used
+*/}}
+{{- define "ydb.webhookPathPrefix" -}}
+{{- default "" .Values.webhook.service.pathPrefix -}}
+{{- if and .Values.webhook.service.pathPrefix (kindIs "bool" .Values.webhook.service.pathPrefix) -}}
+{{- printf "/%s/%s" .Release.Namespace ( include "ydb.fullname" . ) -}}
+{{- end }}
+{{- end }}

--- a/deploy/ydb-operator/templates/webhooks/webhooks.yaml
+++ b/deploy/ydb-operator/templates/webhooks/webhooks.yaml
@@ -20,7 +20,7 @@ webhooks:
       - v1
     clientConfig:
       {{- if not (empty $webhookFqdn) }}
-      url: https://{{ $webhookFqdn }}:{{ $webhookPort }}/validate-ydb-tech-v1alpha1-storage
+      url: https://{{ $webhookFqdn }}:{{ $webhookPort }}{{ template "ydb.webhookPathPrefix" . }}/validate-ydb-tech-v1alpha1-storage
       {{- else}}
       service:
         name: {{ template "ydb.fullname" . }}-webhook
@@ -45,7 +45,7 @@ webhooks:
       - v1
     clientConfig:
       {{- if not (empty $webhookFqdn) }}
-      url: https://{{ $webhookFqdn }}:{{ $webhookPort }}/validate-ydb-tech-v1alpha1-database
+      url: https://{{ $webhookFqdn }}:{{ $webhookPort }}{{ template "ydb.webhookPathPrefix" . }}/validate-ydb-tech-v1alpha1-database
       {{- else}}
       service:
         name: {{ template "ydb.fullname" . }}-webhook
@@ -74,7 +74,7 @@ metadata:
   {{- if .Values.webhook.certManager.enabled }}
   {{- if .Values.webhook.certManager.injectCA }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "ydb.fullname" . }}-webhook
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}{{ template "ydb.webhookPathPrefix" . }}/{{ template "ydb.fullname" . }}-webhook
   {{- end }}
   {{- end }}
 webhooks:
@@ -112,7 +112,7 @@ webhooks:
       - v1
     clientConfig:
       {{- if not (empty $webhookFqdn) }}
-      url: https://{{ $webhookFqdn }}:{{ $webhookPort }}/mutate-ydb-tech-v1alpha1-database
+      url: https://{{ $webhookFqdn }}:{{ $webhookPort }}{{ template "ydb.webhookPathPrefix" . }}/mutate-ydb-tech-v1alpha1-database
       {{- else}}
       service:
         name: {{ template "ydb.fullname" . }}-webhook

--- a/deploy/ydb-operator/values.yaml
+++ b/deploy/ydb-operator/values.yaml
@@ -57,7 +57,7 @@ webhook:
     #  nodePort: 9443
     #
     ## Arbitrary fqdn for WebhookConfiguration instead of a default Service cluster fqdn:
-    fqdn: example.org
+    #  fqdn: example.org
     #
     ## PathPrefix for WebhookConfiguration url when fqdn used
     ## Set variable to true and use default template <namespace>/<release>

--- a/deploy/ydb-operator/values.yaml
+++ b/deploy/ydb-operator/values.yaml
@@ -57,7 +57,15 @@ webhook:
     #  nodePort: 9443
     #
     ## Arbitrary fqdn for WebhookConfiguration instead of a default Service cluster fqdn:
-    #  fqdn: example.org
+    fqdn: example.org
+
+    ## PathPrefix for WebhookConfiguration url when fqdn used
+    ## Set variable to true to use default template <namespace>/<release> or
+    ## write yout own pathPrefix
+    pathPrefix: ""
+    # pathPrefix: true
+    # pathPrefix: "/myPrefix"
+
 
   ## If patch enabled, then generate a self-signed certificate for service.
   ## When injectCA is true should inject the webhook configurations with generated caBundle.

--- a/deploy/ydb-operator/values.yaml
+++ b/deploy/ydb-operator/values.yaml
@@ -57,14 +57,13 @@ webhook:
     #  nodePort: 9443
     #
     ## Arbitrary fqdn for WebhookConfiguration instead of a default Service cluster fqdn:
-    fqdn: example.org
-
+    #  fqdn: example.org
+    #
     ## PathPrefix for WebhookConfiguration url when fqdn used
-    ## Set variable to true to use default template <namespace>/<release> or
-    ## write yout own pathPrefix
-    pathPrefix: ""
-    # pathPrefix: true
-    # pathPrefix: "/myPrefix"
+    ## Set variable to true and use default template <namespace>/<release>
+    #  enableDefaultPathPrefix: false
+    ## Instead of default use your own custom pathPrefix
+    #  customPathPrefix: ""
 
 
   ## If patch enabled, then generate a self-signed certificate for service.

--- a/deploy/ydb-operator/values.yaml
+++ b/deploy/ydb-operator/values.yaml
@@ -57,13 +57,13 @@ webhook:
     #  nodePort: 9443
     #
     ## Arbitrary fqdn for WebhookConfiguration instead of a default Service cluster fqdn:
-    #  fqdn: example.org
+    fqdn: example.org
     #
     ## PathPrefix for WebhookConfiguration url when fqdn used
     ## Set variable to true and use default template <namespace>/<release>
     #  enableDefaultPathPrefix: false
-    ## Instead of default use your own custom pathPrefix
-    #  customPathPrefix: ""
+    ## Instead of default template allowed using your own custom pathPrefix
+    #  customPathPrefix: "/haha"
 
 
   ## If patch enabled, then generate a self-signed certificate for service.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Webhook path hardcoded by kubebuilder annotation (for example https://github.com/ydb-platform/ydb-kubernetes-operator/blob/master/api/v1alpha1/storage_webhook.go#L63)
I want to deploy ydb-operator in more than one namespace and/or helm release with fqdn url usage
In this case I need to set custom pathPrefix and rewrite them by ingress rules

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- define variable `ydb.webhookPathPrefix` described in helm chart _helpers.tpl
- by default webhookPathPrefix equal empty string
- in case when variable set to boolean and true - using template string will be <namespace>/<release>
- in case when variable set to other - using user-defined string in variable

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
