### PR TITLE
Make ability to use priorityClassName

### DIFF
--- a/api/v1alpha1/database_types.go
+++ b/api/v1alpha1/database_types.go
@@ -141,6 +141,10 @@ type DatabaseSpec struct {
 	// (Optional) Additional custom resource annotations that are added to all resources
 	// +optional
 	AdditionalAnnotations map[string]string `json:"additionalAnnotations,omitempty"`
+
+	// (Optional) If specified, the pod's priorityClassName.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 type DatabaseResources struct {

--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -129,6 +129,10 @@ type StorageSpec struct {
 	// (Optional) Additional custom resource annotations that are added to all resources
 	// +optional
 	AdditionalAnnotations map[string]string `json:"additionalAnnotations,omitempty"`
+
+	// (Optional) If specified, the pod's priorityClassName.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 // StorageStatus defines the observed state of Storage

--- a/deploy/ydb-operator/crds/database.yaml
+++ b/deploy/ydb-operator/crds/database.yaml
@@ -2286,6 +2286,9 @@ spec:
                 maxLength: 255
                 pattern: /[a-zA-Z0-9]([-_a-zA-Z0-9]*[a-zA-Z0-9])?/[a-zA-Z0-9]([-_a-zA-Z0-9]*[a-zA-Z0-9])?(/[a-zA-Z0-9]([-_a-zA-Z0-9]*[a-zA-Z0-9])?)*
                 type: string
+              priorityClassName:
+                description: (Optional) If specified, the pod's priorityClassName.
+                type: string
               publicHost:
                 description: '(Optional) Public host to advertise on discovery requests
                   Default: ""'

--- a/deploy/ydb-operator/crds/storage.yaml
+++ b/deploy/ydb-operator/crds/storage.yaml
@@ -2445,6 +2445,9 @@ spec:
                 description: Number of nodes (pods) in the cluster
                 format: int32
                 type: integer
+              priorityClassName:
+                description: (Optional) If specified, the pod's priorityClassName.
+                type: string
               resources:
                 description: '(Optional) Storage container resource limits. Any container
                   limits can be specified. Default: (not specified)'

--- a/internal/resources/database_statefulset.go
+++ b/internal/resources/database_statefulset.go
@@ -96,6 +96,7 @@ func (b *DatabaseStatefulSetBuilder) buildPodTemplateSpec() corev1.PodTemplateSp
 			NodeSelector:              b.Spec.NodeSelector,
 			Affinity:                  b.Spec.Affinity,
 			Tolerations:               b.Spec.Tolerations,
+			PriorityClassName:         b.Spec.PriorityClassName,
 			TopologySpreadConstraints: b.Spec.TopologySpreadConstraints,
 
 			Volumes: b.buildVolumes(),

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -110,6 +110,7 @@ func (b *StorageStatefulSetBuilder) buildPodTemplateSpec() corev1.PodTemplateSpe
 			NodeSelector:              b.Spec.NodeSelector,
 			Affinity:                  b.Spec.Affinity,
 			Tolerations:               b.Spec.Tolerations,
+			PriorityClassName:         b.Spec.PriorityClassName,
 			TopologySpreadConstraints: b.buildTopologySpreadConstraints(),
 
 			Volumes: b.buildVolumes(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Add ability to set priorityClassName in Storage and Database manifests for use them in Statefulset PodSpec
https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
