### PR TITLE
fix: dnsPolicy Default in hostNetwork usage

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -32,7 +32,7 @@ const (
 	DaemonBinaryName = "ydbd"
 
 	AnnotationUpdateStrategyOnDelete = "ydb.tech/update-strategy-on-delete"
-	AnnotationUpdateDnsPolicy        = "ydb.tech/update-dns-policy"
+	AnnotationUpdateDNSPolicy        = "ydb.tech/update-dns-policy"
 	AnnotationSkipInitialization     = "ydb.tech/skip-initialization"
 	AnnotationDisableLivenessProbe   = "ydb.tech/disable-liveness-probe"
 	AnnotationDataCenter             = "ydb.tech/data-center"

--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -32,6 +32,7 @@ const (
 	DaemonBinaryName = "ydbd"
 
 	AnnotationUpdateStrategyOnDelete = "ydb.tech/update-strategy-on-delete"
+	AnnotationUpdateDnsPolicy        = "ydb.tech/update-dns-policy"
 	AnnotationSkipInitialization     = "ydb.tech/skip-initialization"
 	AnnotationDisableLivenessProbe   = "ydb.tech/disable-liveness-probe"
 	AnnotationDataCenter             = "ydb.tech/data-center"

--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.31
+version: 0.4.32
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.31"
+appVersion: "0.4.32"

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -1,0 +1,31 @@
+package annotations
+
+import "strings"
+
+func GetYdbTechAnnotations(annotations map[string]string) map[string]string {
+	result := make(map[string]string)
+	for key, value := range annotations {
+		if strings.HasPrefix(key, "ydb.tech/") {
+			result[key] = value
+		}
+	}
+	return result
+}
+
+func CompareMaps(map1, map2 map[string]string) bool {
+	if len(map1) != len(map2) {
+		return false
+	}
+	for key, value := range map1 {
+		if val, ok := map2[key]; !ok || val != value {
+			return false
+		}
+	}
+	return true
+}
+
+func CompareYdbTechAnnotations(map1, map2 map[string]string) bool {
+	map1 = GetYdbTechAnnotations(map1)
+	map2 = GetYdbTechAnnotations(map2)
+	return CompareMaps(map1, map2)
+}

--- a/internal/controllers/database/controller.go
+++ b/internal/controllers/database/controller.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	ydbv1alpha1 "github.com/ydb-platform/ydb-kubernetes-operator/api/v1alpha1"
+	"github.com/ydb-platform/ydb-kubernetes-operator/internal/annotations"
 )
 
 // Reconciler reconciles a Database object
@@ -66,10 +67,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func ignoreDeletionPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			// Ignore updates to CR status in which case metadata.Generation does not change
+			generationChanged := e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+			annotationsChanged := !annotations.CompareYdbTechAnnotations(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations())
 			_, isService := e.ObjectOld.(*corev1.Service)
 
-			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() || isService
+			return generationChanged || annotationsChanged || isService
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			// Evaluates to false if the object has been confirmed deleted.

--- a/internal/controllers/storage/controller.go
+++ b/internal/controllers/storage/controller.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	ydbv1alpha1 "github.com/ydb-platform/ydb-kubernetes-operator/api/v1alpha1"
+	"github.com/ydb-platform/ydb-kubernetes-operator/internal/annotations"
 )
 
 // Reconciler reconciles a Storage object
@@ -70,10 +71,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func ignoreDeletionPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			// Ignore updates to CR status in which case metadata.Generation does not change
+			generationChanged := e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+			annotationsChanged := !annotations.CompareYdbTechAnnotations(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations())
 			_, isService := e.ObjectOld.(*corev1.Service)
 
-			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() || isService
+			return generationChanged || annotationsChanged || isService
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			// Evaluates to false if the object has been confirmed deleted.

--- a/internal/resources/database_statefulset.go
+++ b/internal/resources/database_statefulset.go
@@ -121,6 +121,17 @@ func (b *DatabaseStatefulSetBuilder) buildPodTemplateSpec() corev1.PodTemplateSp
 	if b.Spec.Image.PullSecret != nil {
 		podTemplate.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: *b.Spec.Image.PullSecret}}
 	}
+
+	if value, ok := b.ObjectMeta.Annotations[v1alpha1.AnnotationUpdateDnsPolicy]; ok {
+		switch value {
+		case string(corev1.DNSClusterFirstWithHostNet), string(corev1.DNSClusterFirst), string(corev1.DNSDefault), string(corev1.DNSNone):
+			podTemplate.Spec.DNSPolicy = corev1.DNSPolicy(value)
+		case "":
+			podTemplate.Spec.DNSPolicy = corev1.DNSClusterFirst
+		default:
+		}
+	}
+
 	return podTemplate
 }
 

--- a/internal/resources/database_statefulset.go
+++ b/internal/resources/database_statefulset.go
@@ -122,7 +122,7 @@ func (b *DatabaseStatefulSetBuilder) buildPodTemplateSpec() corev1.PodTemplateSp
 		podTemplate.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: *b.Spec.Image.PullSecret}}
 	}
 
-	if value, ok := b.ObjectMeta.Annotations[v1alpha1.AnnotationUpdateDnsPolicy]; ok {
+	if value, ok := b.ObjectMeta.Annotations[v1alpha1.AnnotationUpdateDNSPolicy]; ok {
 		switch value {
 		case string(corev1.DNSClusterFirstWithHostNet), string(corev1.DNSClusterFirst), string(corev1.DNSDefault), string(corev1.DNSNone):
 			podTemplate.Spec.DNSPolicy = corev1.DNSPolicy(value)

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -134,12 +134,21 @@ func (b *StorageStatefulSetBuilder) buildPodTemplateSpec() corev1.PodTemplateSpe
 
 	if b.Spec.HostNetwork {
 		podTemplate.Spec.HostNetwork = true
-		podTemplate.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 
 	if b.Spec.Image.PullSecret != nil {
 		podTemplate.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: *b.Spec.Image.PullSecret}}
 	}
+
+	if value, ok := b.ObjectMeta.Annotations[v1alpha1.AnnotationUpdateDnsPolicy]; ok {
+		annotatedDnsPolicy := corev1.DNSPolicy(value)
+		switch annotatedDnsPolicy {
+		case corev1.DNSClusterFirstWithHostNet, corev1.DNSClusterFirst, corev1.DNSDefault, corev1.DNSNone:
+			podTemplate.Spec.DNSPolicy = annotatedDnsPolicy
+		default:
+		}
+	}
+
 	return podTemplate
 }
 

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -140,11 +140,12 @@ func (b *StorageStatefulSetBuilder) buildPodTemplateSpec() corev1.PodTemplateSpe
 		podTemplate.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: *b.Spec.Image.PullSecret}}
 	}
 
-	if value, ok := b.ObjectMeta.Annotations[v1alpha1.AnnotationUpdateDnsPolicy]; ok {
-		annotatedDnsPolicy := corev1.DNSPolicy(value)
-		switch annotatedDnsPolicy {
-		case corev1.DNSClusterFirstWithHostNet, corev1.DNSClusterFirst, corev1.DNSDefault, corev1.DNSNone:
-			podTemplate.Spec.DNSPolicy = annotatedDnsPolicy
+	if value, ok := b.ObjectMeta.Annotations[v1alpha1.AnnotationUpdateDNSPolicy]; ok {
+		switch value {
+		case string(corev1.DNSClusterFirstWithHostNet), string(corev1.DNSClusterFirst), string(corev1.DNSDefault), string(corev1.DNSNone):
+			podTemplate.Spec.DNSPolicy = corev1.DNSPolicy(value)
+		case "":
+			podTemplate.Spec.DNSPolicy = corev1.DNSClusterFirst
 		default:
 		}
 	}


### PR DESCRIPTION
feat: custom dnsPolicy by annotation

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- use dnsPolicy `Default` with hostNetwork usage instead of `ClusterWithHostNet`
- new annotation `ydb.tech/update-dns-policy` to change dnsPolicy in PodSpec 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
