### PR TITLE
Increase go test timeout in e2e tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -162,7 +162,7 @@ jobs:
           kind load docker-image cr.yandex/crptqonuodf51kdj7a7d/ydb:22.4.44
       - name: run-tests
         run: |
-          go test -p 1 ./...
+          go test -timeout 1800s -p 1 ./...
       - name: teardown-k8s-cluster
         run: |
           kind delete cluster


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Increase go test timeout in e2e tests for Github Workflow from 10m to 1800s (30m)

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Tests was failed in previous PR with `ydb-go-sdk` usage. This happened because of connection are waiting for GRPC on `runSelfCheck` call. `clusterDiscovery` RPC method was not available more than 5 minutes through YDB cluster startup time.

Issue Number: N/A

## What is the new behavior?

- Increase go test timeout in e2e tests for Github Workflow from 10m to 1800s (30m)

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
