### PR TITLE
fix: docker/build-push-action use file git context

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -150,6 +150,7 @@ jobs:
       - name: build-operator-image
         uses: docker/build-push-action@v3
         with:
+          context: .
           push: false
           # Get commit short sha within Github action workflow
           # Just a random string name, we aren't uploading anyway


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Using docker/build-push-action with "Path context" instead of "Git context" with auto checkout by buildkit ([docs ref]( https://github.com/docker/build-push-action#git-context))
It's affect docker build command to using current "master" branch from base repository

Example logs:
```
#1 0.029 Initialized empty Git repository in /var/lib/docker/overlay2/68l87isczcrf8vx11byd3u14a/diff/
#1 0.038 fatal: Not a valid object name 5a40a47fb8d35344ccadf1de60ceba95809c3811^{commit}
#1 0.951 From https://github.com/ydb-platform/ydb-kubernetes-operator
```

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Github workflow using docker/build-push-action  with "Git context".
Builded docker image using code from current "master" branch in base repository instead of commit sha fork repository.

Issue Number: N/A

## What is the new behavior?

- docker/build-push-action using "Path context" https://github.com/docker/build-push-action#path-context

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
