### PR TITLE
working with caBundle as env variable oneline base64 string

### DIFF
--- a/api/v1alpha1/database_types.go
+++ b/api/v1alpha1/database_types.go
@@ -103,7 +103,7 @@ type DatabaseSpec struct {
 	// User-defined root certificate authority that is added to system trust
 	// store of Storage pods on startup.
 	// +optional
-	CABundle []byte `json:"caBundle,omitempty"`
+	CABundle string `json:"caBundle,omitempty"`
 
 	// Secret names that will be mounted into the well-known directory of
 	// every storage pod. Directory: `/opt/ydb/secrets/<secret_name>/<secret_key>`

--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -84,7 +84,7 @@ type StorageSpec struct {
 	// User-defined root certificate authority that is added to system trust
 	// store of Storage pods on startup.
 	// +optional
-	CABundle []byte `json:"caBundle,omitempty"`
+	CABundle string `json:"caBundle,omitempty"`
 
 	// Secret names that will be mounted into the well-known directory of
 	// every storage pod. Directory: `/opt/ydb/secrets/<secret_name>/<secret_key>`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -334,11 +334,6 @@ func (in *DatabaseSpec) DeepCopyInto(out *DatabaseSpec) {
 		*out = new(MonitoringOptions)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.CABundle != nil {
-		in, out := &in.CABundle, &out.CABundle
-		*out = make([]byte, len(*in))
-		copy(*out, *in)
-	}
 	if in.Secrets != nil {
 		in, out := &in.Secrets, &out.Secrets
 		*out = make([]*v1.LocalObjectReference, len(*in))
@@ -929,11 +924,6 @@ func (in *StorageSpec) DeepCopyInto(out *StorageSpec) {
 		in, out := &in.Monitoring, &out.Monitoring
 		*out = new(MonitoringOptions)
 		(*in).DeepCopyInto(*out)
-	}
-	if in.CABundle != nil {
-		in, out := &in.CABundle, &out.CABundle
-		*out = make([]byte, len(*in))
-		copy(*out, *in)
 	}
 	if in.Secrets != nil {
 		in, out := &in.Secrets, &out.Secrets

--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.35
+version: 0.4.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.35"
+appVersion: "0.4.36"

--- a/internal/resources/database_statefulset.go
+++ b/internal/resources/database_statefulset.go
@@ -229,7 +229,7 @@ func (b *DatabaseStatefulSetBuilder) buildCaStorePatchingInitContainer() corev1.
 		container.Env = []corev1.EnvVar{
 			{
 				Name:  caBundleEnvName,
-				Value: string(b.Spec.CABundle),
+				Value: b.Spec.CABundle,
 			},
 		}
 	}
@@ -490,7 +490,7 @@ func (b *DatabaseStatefulSetBuilder) buildCaStorePatchingInitContainerArgs() ([]
 	arg := ""
 
 	if len(b.Spec.CABundle) > 0 {
-		arg += fmt.Sprintf("echo $%s > %s/%s && ", caBundleEnvName, localCertsDir, caBundleFileName)
+		arg += fmt.Sprintf("printf $%s | base64 --decode > %s/%s && ", caBundleEnvName, localCertsDir, caBundleFileName)
 	}
 
 	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -254,7 +254,7 @@ func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainer() corev1.C
 		container.Env = []corev1.EnvVar{
 			{
 				Name:  caBundleEnvName,
-				Value: string(b.Spec.CABundle),
+				Value: b.Spec.CABundle,
 			},
 		}
 	}
@@ -427,7 +427,7 @@ func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainerArgs() ([]s
 	arg := ""
 
 	if len(b.Spec.CABundle) > 0 {
-		arg += fmt.Sprintf("echo $%s > %s/%s && ", caBundleEnvName, localCertsDir, caBundleFileName)
+		arg += fmt.Sprintf("printf $%s | base64 --decode > %s/%s && ", caBundleEnvName, localCertsDir, caBundleFileName)
 	}
 
 	if IsGrpcSecure(b.Storage) {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Variable CA_BUNDLE from spec.caBundle printed in incorrect format without '\n' newline symbol

Issue Number: YDBOPS-8714

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Parse variable as string and insert in k8s environment as is
- Execute `printf` with `base64 --decode` instead of `echo` in initContainer

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
