### PR TITLE
annotation for mount secret volume with custom CA certificate

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -41,6 +41,7 @@ const (
 	AnnotationDataCenter             = "ydb.tech/data-center"
 	AnnotationNodeHost               = "ydb.tech/node-host"
 	AnnotationNodeDomain             = "ydb.tech/node-domain"
+	AnnotationCABundleSecret         = "ydb.tech/ca-bundle-secret"
 
 	AnnotationValueTrue = "true"
 

--- a/internal/resources/database_statefulset.go
+++ b/internal/resources/database_statefulset.go
@@ -197,6 +197,17 @@ func (b *DatabaseStatefulSetBuilder) buildVolumes() []corev1.Volume {
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		})
+	} else if value, ok := b.ObjectMeta.Annotations[v1alpha1.AnnotationCABundleSecret]; ok {
+		volumes = append(volumes, corev1.Volume{
+			Name: caCertificatesVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  value,
+					DefaultMode: ptr.Int32(0644),
+					Optional:    ptr.Bool(false),
+				},
+			},
+		})
 	}
 
 	return volumes
@@ -471,6 +482,12 @@ func (b *DatabaseStatefulSetBuilder) buildVolumeMounts() []corev1.VolumeMount {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      systemCertsVolumeName,
 			MountPath: systemCertsDir,
+		})
+	} else if _, ok := b.ObjectMeta.Annotations[v1alpha1.AnnotationCABundleSecret]; ok {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      caCertificatesVolumeName,
+			MountPath: systemCertsDir,
+			ReadOnly:  true,
 		})
 	}
 

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	configVolumeName = "ydb-config"
+	configVolumeName         = "ydb-config"
+	caCertificatesVolumeName = "ca-certificates"
 )
 
 type StorageStatefulSetBuilder struct {
@@ -229,6 +230,17 @@ func (b *StorageStatefulSetBuilder) buildVolumes() []corev1.Volume {
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		})
+	} else if value, ok := b.ObjectMeta.Annotations[v1alpha1.AnnotationCABundleSecret]; ok {
+		volumes = append(volumes, corev1.Volume{
+			Name: caCertificatesVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  value,
+					DefaultMode: ptr.Int32(0644),
+					Optional:    ptr.Bool(false),
+				},
+			},
+		})
 	}
 
 	return volumes
@@ -401,6 +413,12 @@ func (b *StorageStatefulSetBuilder) buildVolumeMounts() []corev1.VolumeMount {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      systemCertsVolumeName,
 			MountPath: systemCertsDir,
+		})
+	} else if _, ok := b.ObjectMeta.Annotations[v1alpha1.AnnotationCABundleSecret]; ok {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      caCertificatesVolumeName,
+			MountPath: systemCertsDir,
+			ReadOnly:  true,
 		})
 	}
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

No way to mount custom ca-certificates bundle in container without usage of initContainer

Issue Number: YDBOPS-8714

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- annotation `ydb.tech/ca-bundle-secret` with value as secretName which mount into container systemCertsDir `/etc/ssl/certs`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Example usage with [trust-manager bundle](docs)(https://cert-manager.io/docs/tutorials/getting-started-with-trust-manager/#mount-trust-bundle-to-application-with-automatic-use))
