### PR TITLE
Pin butlerlogic/action-autotag to 1.1.2 release

### DIFF
--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - id: tag-step
-      uses: butlerlogic/action-autotag@stable
+      uses: butlerlogic/action-autotag@1.1.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Github workflow "upload-artifacts" on master branch seems to broken now

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Explicitly set version of github workflow plugin butlerlogic/action-autotag to @1.1.2

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

A possible temporary workaround as suggested in https://github.com/ButlerLogic/action-autotag/issues/46 and https://github.com/ButlerLogic/action-autotag/issues/45#issuecomment-1825726927
