### PR TITLE
fix e2e check running and ready pods

### DIFF
--- a/e2e/tests/smoke_test.go
+++ b/e2e/tests/smoke_test.go
@@ -30,8 +30,6 @@ const (
 	Interval = time.Second * 5
 )
 
-var HostPathDirectoryType corev1.HostPathType = "Directory"
-
 func podIsReady(conditions []corev1.PodCondition) bool {
 	for _, condition := range conditions {
 		if condition.Type == testobjects.ReadyStatus && condition.Status == "True" {
@@ -39,33 +37,6 @@ func podIsReady(conditions []corev1.PodCondition) bool {
 		}
 	}
 	return false
-}
-
-func execInPod(namespace string, name string, cmd []string) (string, error) {
-	args := []string{
-		"-n",
-		namespace,
-		"exec",
-		name,
-		"--",
-	}
-	args = append(args, cmd...)
-	result := exec.Command("kubectl", args...)
-	stdout, err := result.Output()
-	return string(stdout), err
-}
-
-func bringYdbCliToPod(namespace string, name string, ydbHome string) error {
-	args := []string{
-		"-n",
-		namespace,
-		"cp",
-		fmt.Sprintf("%v/ydb/bin/ydb", os.ExpandEnv("$HOME")),
-		fmt.Sprintf("%v:%v/ydb", name, ydbHome),
-	}
-	result := exec.Command("kubectl", args...)
-	_, err := result.Output()
-	return err
 }
 
 func installOperatorWithHelm(namespace string) bool {
@@ -145,11 +116,67 @@ func checkPodsRunningAndReady(ctx context.Context, podLabelKey, podLabelValue st
 		})).Should(Succeed())
 		g.Expect(len(pods.Items)).Should(BeEquivalentTo(nPods))
 		for _, pod := range pods.Items {
-			g.Expect(pod.Status.Phase).To(BeEquivalentTo("Running"))
-			g.Expect(podIsReady(pod.Status.Conditions)).To(BeTrue())
+			g.Expect(pod.Status.Phase).Should(BeEquivalentTo("Running"))
+			g.Expect(podIsReady(pod.Status.Conditions)).Should(BeTrue())
 		}
 		return true
 	}, Timeout, Interval).Should(BeTrue())
+
+	Consistently(func(g Gomega) bool {
+		pods := corev1.PodList{}
+		g.Expect(k8sClient.List(ctx, &pods, client.InNamespace(testobjects.YdbNamespace), client.MatchingLabels{
+			podLabelKey: podLabelValue,
+		})).Should(Succeed())
+		g.Expect(len(pods.Items)).Should(BeEquivalentTo(nPods))
+		for _, pod := range pods.Items {
+			g.Expect(pod.Status.Phase).Should(BeEquivalentTo("Running"))
+			g.Expect(podIsReady(pod.Status.Conditions)).Should(BeTrue())
+		}
+		return true
+	}, 30*time.Second, Interval).Should(BeTrue())
+}
+
+func bringYdbCliToPod(podName, podNamespace string) {
+	Eventually(func(g Gomega) error {
+		args := []string{
+			"-n",
+			podNamespace,
+			"cp",
+			fmt.Sprintf("%v/ydb/bin/ydb", os.ExpandEnv("$HOME")),
+			fmt.Sprintf("%v:/tmp/ydb", podName),
+		}
+		cmd := exec.Command("kubectl", args...)
+		return cmd.Run()
+	}, Timeout, Interval).Should(BeNil())
+}
+
+func executeSimpleQuery(ctx context.Context, podName, podNamespace, storageEndpoint string) {
+	Eventually(func(g Gomega) string {
+		args := []string{
+			"-n",
+			podNamespace,
+			"exec",
+			podName,
+			"--",
+			"/tmp/ydb",
+			"-d",
+			"/" + testobjects.DefaultDomain,
+			"-e" + storageEndpoint,
+			"yql",
+			"-s",
+			"select 1",
+		}
+		output, err := exec.Command("kubectl", args...).Output()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		// `yql` gives output in the following format:
+		// ┌─────────┐
+		// | column0 |
+		// ├─────────┤
+		// | 1       |
+		// └─────────┘
+		return strings.ReplaceAll(string(output), "\n", "")
+	}, Timeout, Interval).Should(MatchRegexp(".*column0.*1.*"))
 }
 
 var _ = Describe("Operator smoke test", func() {
@@ -206,38 +233,24 @@ var _ = Describe("Operator smoke test", func() {
 		By("checking that all the database pods are running and ready...")
 		checkPodsRunningAndReady(ctx, "ydb-cluster", "kind-database", databaseSample.Spec.Nodes)
 
+		database := v1alpha1.Database{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      databaseSample.Name,
+			Namespace: testobjects.YdbNamespace,
+		}, &database)).Should(Succeed())
+		storageEndpoint := database.Spec.StorageEndpoint
+
 		databasePods := corev1.PodList{}
-		err := k8sClient.List(ctx, &databasePods, client.InNamespace(testobjects.YdbNamespace), client.MatchingLabels{
+		Expect(k8sClient.List(ctx, &databasePods, client.InNamespace(testobjects.YdbNamespace), client.MatchingLabels{
 			"ydb-cluster": "kind-database",
-		})
-		Expect(err).To(BeNil())
-		firstDBPod := databasePods.Items[0].Name
+		})).Should(Succeed())
+		podName := databasePods.Items[0].Name
 
-		Expect(bringYdbCliToPod(testobjects.YdbNamespace, firstDBPod, testobjects.YdbHome)).To(Succeed())
+		By("bring YDB CLI inside ydb database pod...")
+		bringYdbCliToPod(podName, testobjects.YdbNamespace)
 
-		Eventually(func(g Gomega) {
-			out, err := execInPod(testobjects.YdbNamespace, firstDBPod, []string{
-				fmt.Sprintf("%v/ydb", testobjects.YdbHome),
-				"-d",
-				"/" + testobjects.DefaultDomain,
-				"-e",
-				"grpc://localhost:2135",
-				"yql",
-				"-s",
-				"select 1",
-			})
-
-			g.Expect(err).To(BeNil())
-
-			// `yql` gives output in the following format:
-			// ┌─────────┐
-			// | column0 |
-			// ├─────────┤
-			// | 1       |
-			// └─────────┘
-			g.Expect(strings.ReplaceAll(out, "\n", "")).
-				To(MatchRegexp(".*column0.*1.*"))
-		})
+		By("execute simple query inside ydb database pod...")
+		executeSimpleQuery(ctx, podName, testobjects.YdbNamespace, storageEndpoint)
 	})
 
 	It("pause and un-pause Storage, should destroy and bring up Pods", func() {
@@ -417,32 +430,33 @@ var _ = Describe("Operator smoke test", func() {
 		By("checking that all the database pods are running and ready...")
 		checkPodsRunningAndReady(ctx, "ydb-cluster", "kind-database", databaseSample.Spec.Nodes)
 
-		By("delete nodeSetSpec inline to check inheritance...")
 		database := v1alpha1.Database{}
-		Expect(k8sClient.Get(ctx, types.NamespacedName{
-			Name:      databaseSample.Name,
-			Namespace: testobjects.YdbNamespace,
-		}, &database)).Should(Succeed())
-		database.Spec.Nodes = 4
-		database.Spec.NodeSets = []v1alpha1.DatabaseNodeSetSpecInline{
-			{
-				Name: testNodeSetName + "-" + strconv.Itoa(1),
-				DatabaseNodeSpec: v1alpha1.DatabaseNodeSpec{
-					Nodes: 4,
-				},
-			},
-		}
-		Expect(k8sClient.Update(ctx, &database)).Should(Succeed())
-
-		By("check that ObservedDatabaseGeneration changed...")
-		Eventually(func(g Gomega) bool {
-			database := v1alpha1.Database{}
+		databaseNodeSetList := v1alpha1.DatabaseNodeSetList{}
+		databasePods := corev1.PodList{}
+		By("delete nodeSetSpec inline to check inheritance...")
+		Eventually(func(g Gomega) error {
 			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
 				Name:      databaseSample.Name,
 				Namespace: testobjects.YdbNamespace,
 			}, &database)).Should(Succeed())
+			database.Spec.Nodes = 4
+			database.Spec.NodeSets = []v1alpha1.DatabaseNodeSetSpecInline{
+				{
+					Name: testNodeSetName + "-" + strconv.Itoa(1),
+					DatabaseNodeSpec: v1alpha1.DatabaseNodeSpec{
+						Nodes: 4,
+					},
+				},
+			}
+			return k8sClient.Update(ctx, &database)
+		}, Timeout, Interval).Should(BeNil())
 
-			databaseNodeSetList := v1alpha1.DatabaseNodeSetList{}
+		By("check that ObservedDatabaseGeneration changed...")
+		Eventually(func(g Gomega) bool {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      databaseSample.Name,
+				Namespace: testobjects.YdbNamespace,
+			}, &database)).Should(Succeed())
 			g.Expect(k8sClient.List(ctx, &databaseNodeSetList,
 				client.InNamespace(testobjects.YdbNamespace),
 			)).Should(Succeed())
@@ -456,54 +470,28 @@ var _ = Describe("Operator smoke test", func() {
 
 		By("expecting databaseNodeSet pods deletion...")
 		Eventually(func(g Gomega) bool {
-			database := v1alpha1.Database{}
 			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
 				Name:      databaseSample.Name,
 				Namespace: testobjects.YdbNamespace,
 			}, &database)).Should(Succeed())
 
-			databasePods := corev1.PodList{}
 			g.Expect(k8sClient.List(ctx, &databasePods, client.InNamespace(testobjects.YdbNamespace), client.MatchingLabels{
 				"ydb-cluster": "kind-database",
 			})).Should(Succeed())
 			return len(databasePods.Items) == int(database.Spec.Nodes)
 		}, Timeout, Interval).Should(BeTrue())
 
+		storageEndpoint := database.Spec.StorageEndpoint
+		Expect(k8sClient.List(ctx, &databasePods, client.InNamespace(testobjects.YdbNamespace), client.MatchingLabels{
+			"ydb-cluster": "kind-database",
+		})).Should(Succeed())
+		podName := databasePods.Items[0].Name
+
+		By("bring YDB CLI inside ydb database pod...")
+		bringYdbCliToPod(podName, testobjects.YdbNamespace)
+
 		By("execute simple query inside ydb database pod...")
-		databasePods := corev1.PodList{}
-		err := k8sClient.List(ctx, &databasePods,
-			client.InNamespace(testobjects.YdbNamespace),
-			client.MatchingLabels{
-				"ydb-cluster": "kind-database",
-			})
-		Expect(err).To(BeNil())
-		firstDBPod := databasePods.Items[0].Name
-
-		Expect(bringYdbCliToPod(testobjects.YdbNamespace, firstDBPod, testobjects.YdbHome)).To(Succeed())
-
-		Eventually(func(g Gomega) {
-			out, err := execInPod(testobjects.YdbNamespace, firstDBPod, []string{
-				fmt.Sprintf("%v/ydb", testobjects.YdbHome),
-				"-d",
-				"/" + testobjects.DefaultDomain,
-				"-e",
-				"grpc://localhost:2135",
-				"yql",
-				"-s",
-				"select 1",
-			})
-
-			g.Expect(err).To(BeNil())
-
-			// `yql` gives output in the following format:
-			// ┌─────────┐
-			// | column0 |
-			// ├─────────┤
-			// | 1       |
-			// └─────────┘
-			g.Expect(strings.ReplaceAll(out, "\n", "")).
-				To(MatchRegexp(".*column0.*1.*"))
-		})
+		executeSimpleQuery(ctx, podName, testobjects.YdbNamespace, storageEndpoint)
 	})
 
 	It("operatorConnection check, create storage with default staticCredentials", func() {
@@ -538,7 +526,7 @@ var _ = Describe("Operator smoke test", func() {
 		By("tracking storage state changes...")
 		events, err := clientset.CoreV1().Events(testobjects.YdbNamespace).List(context.Background(),
 			metav1.ListOptions{TypeMeta: metav1.TypeMeta{Kind: "Storage"}})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ShouldNot(HaveOccurred())
 
 		allowedChanges := map[ClusterState]ClusterState{
 			StoragePending:      StoragePreparing,
@@ -551,7 +539,7 @@ var _ = Describe("Operator smoke test", func() {
 		for _, event := range events.Items {
 			if event.Reason == "StatusChanged" {
 				match := re.FindStringSubmatch(event.Message)
-				Expect(allowedChanges[ClusterState(match[1])]).To(BeEquivalentTo(ClusterState(match[2])))
+				Expect(allowedChanges[ClusterState(match[1])]).Should(BeEquivalentTo(ClusterState(match[2])))
 			}
 		}
 	})

--- a/e2e/tests/test-objects/objects.go
+++ b/e2e/tests/test-objects/objects.go
@@ -13,7 +13,6 @@ import (
 const (
 	YdbImage      = "cr.yandex/crptqonuodf51kdj7a7d/ydb:22.4.44"
 	YdbNamespace  = "ydb"
-	YdbHome       = "/home/ydb"
 	StorageName   = "storage"
 	DatabaseName  = "database"
 	DefaultDomain = "Root"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Incorrect e2e tests for database readiness and execute simple YQL query

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- use Consistently gomega to checks that pods Running and Ready for a period time equals 30 seconds with 5 seconds polling interval
- copy ydb CLI into pod `/tmp` path to prevent user permission error ([ref discuss](https://discuss.kubernetes.io/t/kubernetes-cp-gives-permission-denied-error/6297))
- eventually wait successfully output from simple YQL query command stdout

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Use only `Should` and `ShouldNot` to make code consistency and uniformity (same as `To` and `ToNot` because syntax sugar - https://onsi.github.io/gomega/#making-assertions)
