### PR TITLE
Fix .spec.image nil pointer

### DIFF
--- a/api/v1alpha1/database_webhook.go
+++ b/api/v1alpha1/database_webhook.go
@@ -68,7 +68,11 @@ func (r *DatabaseDefaulter) Default(ctx context.Context, obj runtime.Object) err
 		}
 	}
 
-	if database.Spec.Image == nil && database.Spec.Image.Name == "" {
+	if database.Spec.Image == nil {
+		database.Spec.Image = &PodImage{}
+	}
+
+	if database.Spec.Image.Name == "" {
 		if database.Spec.YDBVersion == "" {
 			database.Spec.Image.Name = fmt.Sprintf(ImagePathFormat, RegistryPath, DefaultTag)
 		} else {

--- a/api/v1alpha1/storage_webhook.go
+++ b/api/v1alpha1/storage_webhook.go
@@ -75,7 +75,11 @@ func (r *StorageDefaulter) Default(ctx context.Context, obj runtime.Object) erro
 	storage := obj.(*Storage)
 	storagelog.Info("default", "name", storage.Name)
 
-	if storage.Spec.Image == nil || storage.Spec.Image.Name == "" {
+	if storage.Spec.Image == nil {
+		storage.Spec.Image = &PodImage{}
+	}
+
+	if storage.Spec.Image.Name == "" {
 		if storage.Spec.YDBVersion == "" {
 			storage.Spec.Image.Name = fmt.Sprintf(ImagePathFormat, RegistryPath, DefaultTag)
 		} else {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -469,6 +469,11 @@ func (in *DatabaseNodeSpec) DeepCopyInto(out *DatabaseNodeSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.TerminationGracePeriodSeconds != nil {
+		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	if in.AdditionalLabels != nil {
 		in, out := &in.AdditionalLabels, &out.AdditionalLabels
 		*out = make(map[string]string, len(*in))
@@ -482,11 +487,6 @@ func (in *DatabaseNodeSpec) DeepCopyInto(out *DatabaseNodeSpec) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
-	}
-	if in.TerminationGracePeriodSeconds != nil {
-		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
-		*out = new(int64)
-		**out = **in
 	}
 }
 
@@ -1234,6 +1234,11 @@ func (in *StorageNodeSpec) DeepCopyInto(out *StorageNodeSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.TerminationGracePeriodSeconds != nil {
+		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	if in.AdditionalLabels != nil {
 		in, out := &in.AdditionalLabels, &out.AdditionalLabels
 		*out = make(map[string]string, len(*in))
@@ -1247,11 +1252,6 @@ func (in *StorageNodeSpec) DeepCopyInto(out *StorageNodeSpec) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
-	}
-	if in.TerminationGracePeriodSeconds != nil {
-		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
-		*out = new(int64)
-		**out = **in
 	}
 }
 

--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.40
+version: 0.4.41
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.40"
+appVersion: "0.4.41"

--- a/deploy/ydb-operator/crds/database.yaml
+++ b/deploy/ydb-operator/crds/database.yaml
@@ -2266,8 +2266,8 @@ spec:
                   labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                 type: object
               nodeSets:
-                description: (Optional) NodeSet inline configuration to split into
-                  multiple StatefulSets
+                description: '(Optional) NodeSet inline configuration to split into
+                  multiple StatefulSets Default: (not specified)'
                 items:
                   description: DatabaseNodeSetSpecInline describes an group nodes
                     object inside parent object
@@ -3327,6 +3327,10 @@ spec:
                             type: object
                           type: array
                       type: object
+                    terminationGracePeriodSeconds:
+                      description: (Optional) If specified, the pod's terminationGracePeriodSeconds.
+                      format: int64
+                      type: integer
                     tolerations:
                       description: (Optional) If specified, the pod's tolerations.
                       items:
@@ -4063,13 +4067,13 @@ spec:
                 required:
                 - name
                 type: object
+              storageEndpoint:
+                description: YDB Storage Node broker address
+                type: string
               terminationGracePeriodSeconds:
                 description: (Optional) If specified, the pod's terminationGracePeriodSeconds.
                 format: int64
                 type: integer
-              storageEndpoint:
-                description: YDB Storage Node broker address
-                type: string
               tolerations:
                 description: (Optional) If specified, the pod's tolerations.
                 items:

--- a/deploy/ydb-operator/crds/databasenodeset.yaml
+++ b/deploy/ydb-operator/crds/databasenodeset.yaml
@@ -2791,6 +2791,10 @@ spec:
               storageEndpoint:
                 description: YDB Storage Node broker address
                 type: string
+              terminationGracePeriodSeconds:
+                description: (Optional) If specified, the pod's terminationGracePeriodSeconds.
+                format: int64
+                type: integer
               tolerations:
                 description: (Optional) If specified, the pod's tolerations.
                 items:

--- a/deploy/ydb-operator/crds/storage.yaml
+++ b/deploy/ydb-operator/crds/storage.yaml
@@ -3607,6 +3607,10 @@ spec:
                             https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
+                    terminationGracePeriodSeconds:
+                      description: (Optional) If specified, the pod's terminationGracePeriodSeconds.
+                      format: int64
+                      type: integer
                     tolerations:
                       description: (Optional) If specified, the pod's tolerations.
                       items:

--- a/deploy/ydb-operator/crds/storagenodeset.yaml
+++ b/deploy/ydb-operator/crds/storagenodeset.yaml
@@ -2784,6 +2784,10 @@ spec:
                 required:
                 - name
                 type: object
+              terminationGracePeriodSeconds:
+                description: (Optional) If specified, the pod's terminationGracePeriodSeconds.
+                format: int64
+                type: integer
               tolerations:
                 description: (Optional) If specified, the pod's tolerations.
                 items:

--- a/e2e/tests/smoke_test.go
+++ b/e2e/tests/smoke_test.go
@@ -195,7 +195,6 @@ var _ = Describe("Operator smoke test", func() {
 
 		databaseSample.Spec.StorageClusterRef.Namespace = ""
 		databaseSample.Spec.Image = nil
-		databaseSample.Spec.Resources = nil
 		databaseSample.Spec.Service = nil
 		databaseSample.Spec.Domain = ""
 		databaseSample.Spec.Path = ""

--- a/e2e/tests/smoke_test.go
+++ b/e2e/tests/smoke_test.go
@@ -183,6 +183,32 @@ var _ = Describe("Operator smoke test", func() {
 		Expect(installOperatorWithHelm(testobjects.YdbNamespace)).Should(BeTrue())
 	})
 
+	It("Check webhook defaulter", func() {
+		storageSample.Spec.Image = nil
+		storageSample.Spec.Resources = nil
+		storageSample.Spec.Service = nil
+		storageSample.Spec.Monitoring = nil
+		Expect(k8sClient.Create(ctx, storageSample)).Should(Succeed())
+		defer func() {
+			Expect(k8sClient.Delete(ctx, storageSample)).Should(Succeed())
+		}()
+
+		databaseSample.Spec.StorageClusterRef.Namespace = ""
+		databaseSample.Spec.Image = nil
+		databaseSample.Spec.Resources = nil
+		databaseSample.Spec.Service = nil
+		databaseSample.Spec.Domain = ""
+		databaseSample.Spec.Path = ""
+		databaseSample.Spec.Encryption = nil
+		databaseSample.Spec.Datastreams = nil
+		databaseSample.Spec.Monitoring = nil
+		databaseSample.Spec.StorageEndpoint = ""
+		Expect(k8sClient.Create(ctx, databaseSample)).Should(Succeed())
+		defer func() {
+			Expect(k8sClient.Delete(ctx, databaseSample)).Should(Succeed())
+		}()
+	})
+
 	It("general smoke pipeline, create storage + database", func() {
 		By("issuing create commands...")
 		Expect(k8sClient.Create(ctx, storageSample)).Should(Succeed())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

nil pointer when keep .spec.Image is empty field

`
2024/01/31 11:56:15 http: panic serving [2a02:6b8:c08:b58d:0:1517:2:ec]:60364: runtime error: invalid memory address or nil pointer dereference
goroutine 49187 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1850 +0xbf
panic({0x1991240, 0x2d46090})
	/usr/local/go/src/runtime/panic.go:890 +0x262
github.com/ydb-platform/ydb-kubernetes-operator/api/v1alpha1.(*StorageDefaulter).Default(0xc000d51f20?, {0x24?, 0xc0009f9998?}, {0x1f044e0?, 0xc0004deb00})
	/workspace/api/v1alpha1/storage_webhook.go:80 +0x16b
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*defaulterForType).Handle(_, {_, _}, {{{0xc000d51f20, 0x24}, {{0xc0009f9998, 0x8}, {0xc0009f99c0, 0x8}, {0xc0009f99c8, ...}}, ...}})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/webhook/admission/defaulter_custom.go:84 +0x2fd
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle(_, {_, _}, {{{0xc000d51f20, 0x24}, {{0xc0009f9998, 0x8}, {0xc0009f99c0, 0x8}, {0xc0009f99c8, ...}}, ...}})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/webhook/admission/webhook.go:169 +0xfd
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP(0xc000ab1000, {0x7f69652b3bc0?, 0xc0008157c0}, 0xc0009f7400)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/webhook/admission/http.go:98 +0xed2
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerInFlight.func1({0x7f69652b3bc0, 0xc0008157c0}, 0x1f16300?)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.14.0/prometheus/promhttp/instrument_server.go:60 +0xd4
net/http.HandlerFunc.ServeHTTP(0x1f163f0?, {0x7f69652b3bc0?, 0xc0008157c0?}, 0x7ba3e0?)
	/usr/local/go/src/net/http/server.go:2109 +0x2f
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1({0x1f163f0?, 0xc000826e00?}, 0xc0009f7400)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.14.0/prometheus/promhttp/instrument_server.go:146 +0xb8
net/http.HandlerFunc.ServeHTTP(0x0?, {0x1f163f0?, 0xc000826e00?}, 0xc000d51e60?)
	/usr/local/go/src/net/http/server.go:2109 +0x2f
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2({0x1f163f0, 0xc000826e00}, 0xc0009f7400)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.14.0/prometheus/promhttp/instrument_server.go:108 +0xbf
net/http.HandlerFunc.ServeHTTP(0xc000826e00?, {0x1f163f0?, 0xc000826e00?}, 0x1c4ecef?)
	/usr/local/go/src/net/http/server.go:2109 +0x2f
net/http.(*ServeMux).ServeHTTP(0xc000c8d8a7?, {0x1f163f0, 0xc000826e00}, 0xc0009f7400)
	/usr/local/go/src/net/http/server.go:2487 +0x149
net/http.serverHandler.ServeHTTP({0x1f08360?}, {0x1f163f0, 0xc000826e00}, 0xc0009f7400)
	/usr/local/go/src/net/http/server.go:2947 +0x30c
net/http.(*conn).serve(0xc0006adcc0, {0x1f175b0, 0xc000599b30})
	/usr/local/go/src/net/http/server.go:1991 +0x607
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:3102 +0x4db
`

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- fix nil pointer
- bump version

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

generate manifests from previous changes