### PR TITLE
Fix initJob restart condition

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -63,7 +63,6 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.48.0
-          args: --out-format=colored-line-number
   code-format-check:
     concurrency:
       group: lint-autoformat-${{ github.ref }}

--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.0"
+appVersion: "0.5.1"

--- a/internal/controllers/storage/init.go
+++ b/internal/controllers/storage/init.go
@@ -202,8 +202,7 @@ func (r *Reconciler) initializeStorage(
 			break
 		}
 	}
-
-	if initJob.Status.Failed > 0 || conditionFailed {
+	if initJob.Status.Failed == *initJob.Spec.BackoffLimit || conditionFailed {
 		r.Log.Info("Init Job status failed")
 		r.Recorder.Event(
 			storage,

--- a/internal/controllers/storage/init.go
+++ b/internal/controllers/storage/init.go
@@ -195,7 +195,15 @@ func (r *Reconciler) initializeStorage(
 		return r.setInitStorageCompleted(ctx, storage, "Storage initialized successfully")
 	}
 
-	if initJob.Status.Failed > 0 {
+	var conditionFailed bool
+	for _, condition := range initJob.Status.Conditions {
+		if condition.Type == batchv1.JobFailed {
+			conditionFailed = true
+			break
+		}
+	}
+
+	if initJob.Status.Failed > 0 || conditionFailed {
 		r.Log.Info("Init Job status failed")
 		r.Recorder.Event(
 			storage,

--- a/internal/resources/database.go
+++ b/internal/resources/database.go
@@ -281,10 +281,6 @@ func (b *DatabaseBuilder) recastDatabaseNodeSetSpecInline(nodeSetSpecInline *api
 		nodeSetSpec.Tolerations = append(nodeSetSpec.Tolerations, nodeSetSpecInline.Tolerations...)
 	}
 
-	if nodeSetSpecInline.PriorityClassName != nodeSetSpec.PriorityClassName {
-		nodeSetSpec.PriorityClassName = nodeSetSpecInline.PriorityClassName
-	}
-
 	nodeSetSpec.AdditionalLabels = CopyDict(b.Spec.AdditionalLabels)
 	if nodeSetSpecInline.AdditionalLabels != nil {
 		for k, v := range nodeSetSpecInline.AdditionalLabels {

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -212,10 +212,6 @@ func (b *StorageClusterBuilder) recastStorageNodeSetSpecInline(nodeSetSpecInline
 		nodeSetSpec.Resources = nodeSetSpecInline.Resources
 	}
 
-	if nodeSetSpecInline.HostNetwork != nodeSetSpec.HostNetwork {
-		nodeSetSpec.HostNetwork = nodeSetSpecInline.HostNetwork
-	}
-
 	nodeSetSpec.NodeSelector = CopyDict(b.Spec.NodeSelector)
 	if nodeSetSpecInline.NodeSelector != nil {
 		for k, v := range nodeSetSpecInline.NodeSelector {
@@ -233,10 +229,6 @@ func (b *StorageClusterBuilder) recastStorageNodeSetSpecInline(nodeSetSpecInline
 
 	if nodeSetSpecInline.TopologySpreadConstraints != nil {
 		nodeSetSpec.TopologySpreadConstraints = append(nodeSetSpec.TopologySpreadConstraints, nodeSetSpecInline.TopologySpreadConstraints...)
-	}
-
-	if nodeSetSpecInline.PriorityClassName != nodeSetSpec.PriorityClassName {
-		nodeSetSpec.PriorityClassName = nodeSetSpecInline.PriorityClassName
 	}
 
 	nodeSetSpec.AdditionalLabels = CopyDict(b.Spec.AdditionalLabels)

--- a/internal/resources/storage_init_job.go
+++ b/internal/resources/storage_init_job.go
@@ -40,7 +40,7 @@ func (b *StorageInitJobBuilder) Build(obj client.Object) error {
 		Parallelism:           ptr.Int32(1),
 		Completions:           ptr.Int32(1),
 		ActiveDeadlineSeconds: ptr.Int64(300),
-		BackoffLimit:          ptr.Int32(10),
+		BackoffLimit:          ptr.Int32(3),
 		Template:              b.buildInitJobPodTemplateSpec(),
 	}
 
@@ -91,7 +91,7 @@ func (b *StorageInitJobBuilder) buildInitJobPodTemplateSpec() corev1.PodTemplate
 		Spec: corev1.PodSpec{
 			Containers:    []corev1.Container{b.buildInitJobContainer()},
 			Volumes:       b.buildInitJobVolumes(),
-			RestartPolicy: corev1.RestartPolicyOnFailure,
+			RestartPolicy: corev1.RestartPolicyNever,
 			DNSConfig: &corev1.PodDNSConfig{
 				Searches: dnsConfigSearches,
 			},

--- a/internal/resources/storage_init_job.go
+++ b/internal/resources/storage_init_job.go
@@ -40,7 +40,7 @@ func (b *StorageInitJobBuilder) Build(obj client.Object) error {
 		Parallelism:           ptr.Int32(1),
 		Completions:           ptr.Int32(1),
 		ActiveDeadlineSeconds: ptr.Int64(300),
-		BackoffLimit:          ptr.Int32(1),
+		BackoffLimit:          ptr.Int32(10),
 		Template:              b.buildInitJobPodTemplateSpec(),
 	}
 
@@ -91,7 +91,7 @@ func (b *StorageInitJobBuilder) buildInitJobPodTemplateSpec() corev1.PodTemplate
 		Spec: corev1.PodSpec{
 			Containers:    []corev1.Container{b.buildInitJobContainer()},
 			Volumes:       b.buildInitJobVolumes(),
-			RestartPolicy: corev1.RestartPolicyNever,
+			RestartPolicy: corev1.RestartPolicyOnFailure,
 			DNSConfig: &corev1.PodDNSConfig{
 				Searches: dnsConfigSearches,
 			},

--- a/internal/resources/storage_init_job.go
+++ b/internal/resources/storage_init_job.go
@@ -40,7 +40,7 @@ func (b *StorageInitJobBuilder) Build(obj client.Object) error {
 		Parallelism:           ptr.Int32(1),
 		Completions:           ptr.Int32(1),
 		ActiveDeadlineSeconds: ptr.Int64(300),
-		BackoffLimit:          ptr.Int32(10),
+		BackoffLimit:          ptr.Int32(1),
 		Template:              b.buildInitJobPodTemplateSpec(),
 	}
 
@@ -91,7 +91,7 @@ func (b *StorageInitJobBuilder) buildInitJobPodTemplateSpec() corev1.PodTemplate
 		Spec: corev1.PodSpec{
 			Containers:    []corev1.Container{b.buildInitJobContainer()},
 			Volumes:       b.buildInitJobVolumes(),
-			RestartPolicy: corev1.RestartPolicyOnFailure,
+			RestartPolicy: corev1.RestartPolicyNever,
 			DNSConfig: &corev1.PodDNSConfig{
 				Searches: dnsConfigSearches,
 			},


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- job.status updated inconsistently by [kubernetes issue](https://github.com/kubernetes/kubernetes/issues/94921#issuecomment-706546623)
- hostNetwork default value in nodeSetSpecInline equal false that does not satisfy with primary resource spec
- priorityClassName value in nodeSetSpecInline equal empty string that does not satisfy with primary resource spec

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add check for initJob field `.status.conditions` for Failed type
- Set `restartPolicy: Never` in podTemplate initJob for correct count backoffLimit
- Inherit fields hostNetwork and priorityClassName for nodeSets from primary resources spec

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
