### PR TITLE
Start pushing artifacts to Dockerhub registries

### DIFF
--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -99,3 +99,20 @@ jobs:
 
         aws s3 --endpoint-url=https://storage.yandexcloud.net \
           cp ./charts/index.yaml s3://charts.ydb.tech/index.yaml
+    - name: docker-login-to-dockerhub
+      uses: docker/login-action@v3
+      with:
+        username: ydbplatform
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    - name: push-image-to-dockerhub
+      run: |
+        docker build -t ydbplatform/ydb-kubernetes-operator:"$VERSION" .
+        docker push ydbplatform/ydb-kubernetes-operator:"$VERSION"
+    - name: helm-login-to-dockerhub
+      run: |
+        helm registry login registry-1.docker.io \
+          --username ydbplatform \
+          --password ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    - name: push-helm-chart-to-dockerhub
+      run: |
+        helm push ./ydb-operator-"$VERSION".tgz oci://registry-1.docker.io/ydbplatform

--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.6
+version: 0.5.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.6"
+appVersion: "0.5.7"

--- a/deploy/ydb-operator/templates/deployment.yaml
+++ b/deploy/ydb-operator/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             {{- end }}
           command:
             - /manager
-          image: {{ default "cr.yandex/yc/ydb-kubernetes-operator" .Values.image.repository }}:
+          image: {{ default "ydbplatform/ydb-kubernetes-operator " .Values.image.repository }}:
             {{- if eq .Values.image.tag "REPLACED_BY_CHART_APP_VERSION_IF_UNSPECIFIED" -}}
               {{- .Chart.AppVersion -}}
             {{- else -}}

--- a/deploy/ydb-operator/templates/deployment.yaml
+++ b/deploy/ydb-operator/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             {{- end }}
           command:
             - /manager
-          image: {{ default "ydbplatform/ydb-kubernetes-operator " .Values.image.repository }}:
+          image: {{ default "ydbplatform/ydb-kubernetes-operator" .Values.image.repository }}:
             {{- if eq .Values.image.tag "REPLACED_BY_CHART_APP_VERSION_IF_UNSPECIFIED" -}}
               {{- .Chart.AppVersion -}}
             {{- else -}}

--- a/deploy/ydb-operator/values.yaml
+++ b/deploy/ydb-operator/values.yaml
@@ -5,7 +5,7 @@ image:
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
   pullPolicy: IfNotPresent
-  repository: cr.yandex/yc/ydb-kubernetes-operator
+  repository: ydbplatform/ydb-kubernetes-operator
   tag: "REPLACED_BY_CHART_APP_VERSION_IF_UNSPECIFIED"
 
 ## Secrets to use for Docker registry access


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

- Image and helm chart will now ALSO be pushed to new public registries: `ydbplatform/ydb-kubernetes-operator` for the image and `ydbplatform/ydb-operator` for the helm chart
- Naming of the chart and image is preserved
- Old repositories will be deprecated soon 

## Other information

