### PR TITLE
YDBOPS-9722 fillMissingSections for ConfigMap on operator upgrade

### DIFF
--- a/api/v1alpha1/configuration.go
+++ b/api/v1alpha1/configuration.go
@@ -89,7 +89,7 @@ func tryFillMissingSections(
 	}
 }
 
-func buildConfiguration(cr *Storage, crDB *Database) (string, error) {
+func BuildConfiguration(cr *Storage, crDB *Database) (string, error) {
 	config := make(map[string]interface{})
 
 	// If any kind of configuration exists on Database object, then

--- a/api/v1alpha1/database_webhook.go
+++ b/api/v1alpha1/database_webhook.go
@@ -142,7 +142,7 @@ func (r *DatabaseDefaulter) Default(ctx context.Context, obj runtime.Object) err
 	}
 
 	if database.Spec.Configuration != "" || (database.Spec.Encryption != nil && database.Spec.Encryption.Enabled) {
-		configuration, err := buildConfiguration(storage, database)
+		configuration, err := BuildConfiguration(storage, database)
 		if err != nil {
 			return err
 		}

--- a/api/v1alpha1/storage_webhook.go
+++ b/api/v1alpha1/storage_webhook.go
@@ -166,7 +166,7 @@ func (r *StorageDefaulter) Default(ctx context.Context, obj runtime.Object) erro
 		storage.Spec.Domain = DefaultDatabaseDomain
 	}
 
-	configuration, err := buildConfiguration(storage, nil)
+	configuration, err := BuildConfiguration(storage, nil)
 	if err != nil {
 		return err
 	}

--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.12
+version: 0.5.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.12"
+appVersion: "0.5.13"

--- a/internal/controllers/remotestoragenodeset/controller_test.go
+++ b/internal/controllers/remotestoragenodeset/controller_test.go
@@ -192,7 +192,7 @@ var _ = Describe("RemoteStorageNodeSet controller tests", func() {
 				Cluster: testRemoteCluster,
 			},
 			StorageNodeSpec: v1alpha1.StorageNodeSpec{
-				Nodes: 8,
+				Nodes: 2,
 			},
 		})
 		storageSample.Spec.NodeSets = append(storageSample.Spec.NodeSets, v1alpha1.StorageNodeSetSpecInline{
@@ -201,7 +201,7 @@ var _ = Describe("RemoteStorageNodeSet controller tests", func() {
 				Cluster: testRemoteCluster,
 			},
 			StorageNodeSpec: v1alpha1.StorageNodeSpec{
-				Nodes: 4,
+				Nodes: 2,
 			},
 		})
 
@@ -568,7 +568,7 @@ var _ = Describe("RemoteStorageNodeSet controller tests", func() {
 					{
 						Name: testNodeSetName + "-local",
 						StorageNodeSpec: v1alpha1.StorageNodeSpec{
-							Nodes: 4,
+							Nodes: 6,
 						},
 					},
 					{
@@ -577,7 +577,7 @@ var _ = Describe("RemoteStorageNodeSet controller tests", func() {
 							Cluster: testRemoteCluster,
 						},
 						StorageNodeSpec: v1alpha1.StorageNodeSpec{
-							Nodes: 8,
+							Nodes: 2,
 						},
 					},
 				}

--- a/internal/resources/database.go
+++ b/internal/resources/database.go
@@ -50,7 +50,6 @@ func (b *DatabaseBuilder) GetResourceBuilders(restConfig *rest.Config) []Resourc
 	var optionalBuilders []ResourceBuilder
 
 	if b.Spec.Configuration != "" {
-
 		// YDBOPS-9722 backward compatibility
 		cfg, _ := api.BuildConfiguration(b.Storage, b.Unwrap())
 

--- a/internal/resources/database.go
+++ b/internal/resources/database.go
@@ -50,6 +50,10 @@ func (b *DatabaseBuilder) GetResourceBuilders(restConfig *rest.Config) []Resourc
 	var optionalBuilders []ResourceBuilder
 
 	if b.Spec.Configuration != "" {
+
+		// YDBOPS-9722 backward compability
+		cfg, _ := api.BuildConfiguration(b.Storage, b.Unwrap())
+
 		optionalBuilders = append(
 			optionalBuilders,
 			&ConfigMapBuilder{
@@ -57,7 +61,7 @@ func (b *DatabaseBuilder) GetResourceBuilders(restConfig *rest.Config) []Resourc
 
 				Name: b.GetName(),
 				Data: map[string]string{
-					api.ConfigFileName: b.Spec.Configuration,
+					api.ConfigFileName: cfg,
 				},
 				Labels: databaseLabels,
 			},

--- a/internal/resources/database.go
+++ b/internal/resources/database.go
@@ -51,7 +51,7 @@ func (b *DatabaseBuilder) GetResourceBuilders(restConfig *rest.Config) []Resourc
 
 	if b.Spec.Configuration != "" {
 
-		// YDBOPS-9722 backward compability
+		// YDBOPS-9722 backward compatibility
 		cfg, _ := api.BuildConfiguration(b.Storage, b.Unwrap())
 
 		optionalBuilders = append(

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -39,13 +39,17 @@ func (b *StorageClusterBuilder) GetResourceBuilders(restConfig *rest.Config) []R
 	statusServiceLabels.Merge(map[string]string{labels.ServiceComponent: labels.StatusComponent})
 
 	var optionalBuilders []ResourceBuilder
+
+	// YDBOPS-9722 backward compability
+	cfg, _ := api.BuildConfiguration(b.Unwrap(), nil)
+
 	optionalBuilders = append(
 		optionalBuilders,
 		&ConfigMapBuilder{
 			Object: b,
 			Name:   b.Storage.GetName(),
 			Data: map[string]string{
-				api.ConfigFileName: b.Spec.Configuration,
+				api.ConfigFileName: cfg,
 			},
 			Labels: storageLabels,
 		},

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -40,7 +40,7 @@ func (b *StorageClusterBuilder) GetResourceBuilders(restConfig *rest.Config) []R
 
 	var optionalBuilders []ResourceBuilder
 
-	// YDBOPS-9722 backward compability
+	// YDBOPS-9722 backward compatibility
 	cfg, _ := api.BuildConfiguration(b.Unwrap(), nil)
 
 	optionalBuilders = append(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In new versions of ydb-operator, the logic of configuration generation for Storage/Database objects has changed - the hosts section is generated by mutationWebhook and then paste into ConfigMap during resource synchronization. In previous versions of the operator, the hosts section was added at the stage of creating the ConfigMap https://github.com/ydb-platform/ydb-kubernetes-operator/blob/0.4.30/internal/resources/database.go#L84.

When user updating the version of the ydb-operator, the  mutating/validating webhook is not executed (because they are processed by the k8s api server), and therefore the hosts section for .spec.configuration in the Database is not registered here https://github.com/ydb-platform/ydb-kubernetes-operator/blob/0.5.2/api/v1alpha1/database_webhook.go#L131-L148. Then Database object updates the ConfigMap without generated hosts section https://github.com/ydb-platform/ydb-kubernetes-operator/blob/0.5.2/internal/resources/database.go#L75-L86

Issue Number: YDBOPS-9722

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- add a check for the presence of the hosts section before updating ConfigMap in Database/Storage objects to avoid broken configuration when updating versions of ydb-operator

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
