### PR TITLE
bump golang to version 1.20

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
       - name: set-env-vars
         run: |
           echo "HOME=/actions-runner" >> $GITHUB_ENV
@@ -75,7 +75,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
       - name: set-env-vars
         run: |
           echo "HOME=/actions-runner" >> $GITHUB_ENV
@@ -98,7 +98,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
       - name: install-dependencies
         run: |
           sudo apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 
 WORKDIR /workspace
 COPY go.mod go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ydb-platform/ydb-kubernetes-operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/banzaicloud/k8s-objectmatcher v1.7.0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

bump golang version to 1.20 due to the need to use a new version for ydb-go-sdk libraries

```
# github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring
Error: ../../../go/pkg/mod/github.com/ydb-platform/ydb-go-sdk/v3@v3.74.2/internal/xstring/convert.go:15:16: undefined: unsafe.String
Error: ../../../go/pkg/mod/github.com/ydb-platform/ydb-go-sdk/v3@v3.74.2/internal/xstring/convert.go:23:29: undefined: unsafe.StringData
note: module requires Go 1.20
```

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
