### PR TITLE
bump e2e tests timeout to 1 hour

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -163,7 +163,7 @@ jobs:
           kind load docker-image cr.yandex/crptqonuodf51kdj7a7d/ydb:23.3.17
       - name: run-tests
         run: |
-          go test -v -timeout 1800s -p 1 ./... -args -ginkgo.v
+          go test -v -timeout 3600s -p 1 ./... -args -ginkgo.v
       - name: teardown-k8s-cluster
         run: |
           kind delete cluster


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- bump e2e tests timeout to 1 hour in github ci action 'run-tests'

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
