### PR TITLE
fix panic on GetHostFromConfigEndpoint

### DIFF
--- a/api/v1alpha1/configuration.go
+++ b/api/v1alpha1/configuration.go
@@ -122,12 +122,23 @@ func BuildConfiguration(cr *Storage, crDB *Database) ([]byte, error) {
 	return yaml.Marshal(config)
 }
 
-func ParseConfig(rawYamlConfiguration string) (schema.Configuration, error) {
-	config := schema.Configuration{}
+func ParseConfiguration(rawYamlConfiguration string) (schema.Configuration, error) {
+	configuration := schema.Configuration{}
+
+	dynconfig, err := ParseDynconfig(rawYamlConfiguration)
+	if err == nil {
+		config, err := yaml.Marshal(dynconfig.Config)
+		if err != nil {
+			return configuration, err
+		}
+		rawYamlConfiguration = string(config)
+	}
+
 	dec := yaml.NewDecoder(bytes.NewReader([]byte(rawYamlConfiguration)))
 	dec.KnownFields(false)
-	err := dec.Decode(&config)
-	return config, err
+	err = dec.Decode(&configuration)
+
+	return configuration, err
 }
 
 func ParseDynconfig(rawYamlConfiguration string) (schema.Dynconfig, error) {

--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.16
+version: 0.5.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.16"
+appVersion: "0.5.17"

--- a/internal/configuration/schema/schema_test.go
+++ b/internal/configuration/schema/schema_test.go
@@ -122,8 +122,8 @@ var _ = Describe("Testing schema", func() {
 		Expect(err).Should(HaveOccurred())
 	})
 
-	It("Parse static config", func() {
-		yamlConfig, err := v1alpha1.ParseConfig(configurationExample)
+	It("Parse configuration with static config", func() {
+		yamlConfig, err := v1alpha1.ParseConfiguration(configurationExample)
 		Expect(err).ShouldNot(HaveOccurred())
 		hosts := []schema.Host{}
 		for i := 0; i < 8; i++ {
@@ -148,5 +148,10 @@ var _ = Describe("Testing schema", func() {
 				},
 			},
 		}))
+	})
+
+	It("Parse configuration with dynamic config", func() {
+		_, err := v1alpha1.ParseConfiguration(dynconfigExample)
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- fix panic on GetHostFromConfigEndpoint

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

```
panic: interface conversion: interface {} is []interface {}, not []schema.Host [recovered]
	panic: interface conversion: interface {} is []interface {}, not []schema.Host

goroutine 689 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:119 +0x1fa
panic({0x1b4f8c0, 0xc003a9d800})
	/usr/local/go/src/runtime/panic.go:884 +0x213
github.com/ydb-platform/ydb-kubernetes-operator/api/v1alpha1.(*Storage).GetHostFromConfigEndpoint(0xc000bbe2c0)
	/workspace/api/v1alpha1/storage_webhook.go:69 +0x177
```