### PR TITLE
Use StatefulSet status instead of List Pod by selector labels

### DIFF
--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.17
+version: 0.5.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.17"
+appVersion: "0.5.18"

--- a/internal/controllers/database/sync.go
+++ b/internal/controllers/database/sync.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/ydb-platform/ydb-kubernetes-operator/api/v1alpha1"
 	. "github.com/ydb-platform/ydb-kubernetes-operator/internal/controllers/constants" //nolint:revive,stylecheck
-	"github.com/ydb-platform/ydb-kubernetes-operator/internal/labels"
 	"github.com/ydb-platform/ydb-kubernetes-operator/internal/resources"
 )
 
@@ -304,11 +303,11 @@ func (r *Reconciler) waitForStatefulSetToScale(
 		return Continue, ctrl.Result{Requeue: false}, nil
 	}
 
-	found := &appsv1.StatefulSet{}
+	foundStatefulSet := &appsv1.StatefulSet{}
 	err := r.Get(ctx, types.NamespacedName{
 		Name:      database.Name,
 		Namespace: database.Namespace,
-	}, found)
+	}, foundStatefulSet)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			r.Recorder.Event(
@@ -328,42 +327,18 @@ func (r *Reconciler) waitForStatefulSetToScale(
 		return Stop, ctrl.Result{RequeueAfter: DefaultRequeueDelay}, err
 	}
 
-	podList := &corev1.PodList{}
-	opts := []client.ListOption{
-		client.InNamespace(database.Namespace),
-		client.MatchingLabels{labels.StatefulsetComponent: database.Name},
-	}
-
-	err = r.List(ctx, podList, opts...)
-	if err != nil {
-		r.Recorder.Event(
-			database,
-			corev1.EventTypeWarning,
-			"ControllerError",
-			fmt.Sprintf("Failed to list StatefulSet pods: %s", err),
-		)
-		return Stop, ctrl.Result{RequeueAfter: DefaultRequeueDelay}, err
-	}
-
-	runningPods := 0
-	for _, e := range podList.Items {
-		if resources.PodIsReady(e) {
-			runningPods++
-		}
-	}
-
-	if runningPods != int(database.Spec.Nodes) {
+	if foundStatefulSet.Status.ReadyReplicas != database.Spec.Nodes {
 		r.Recorder.Event(
 			database,
 			corev1.EventTypeNormal,
 			string(DatabaseProvisioning),
-			fmt.Sprintf("Waiting for number of running pods to match expected: %d != %d", runningPods, database.Spec.Nodes),
+			fmt.Sprintf("Waiting for number of running pods to match expected: %d != %d", foundStatefulSet.Status.ReadyReplicas, database.Spec.Nodes),
 		)
 		meta.SetStatusCondition(&database.Status.Conditions, metav1.Condition{
 			Type:    DatabaseProvisionedCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  ReasonInProgress,
-			Message: fmt.Sprintf("Number of running pods does not match expected: %d != %d", runningPods, database.Spec.Nodes),
+			Message: fmt.Sprintf("Number of running pods does not match expected: %d != %d", foundStatefulSet.Status.ReadyReplicas, database.Spec.Nodes),
 		})
 		return r.updateStatus(ctx, database, DefaultRequeueDelay)
 	}

--- a/internal/controllers/storage/sync.go
+++ b/internal/controllers/storage/sync.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ydb-platform/ydb-kubernetes-operator/api/v1alpha1"
 	. "github.com/ydb-platform/ydb-kubernetes-operator/internal/controllers/constants" //nolint:revive,stylecheck
 	"github.com/ydb-platform/ydb-kubernetes-operator/internal/healthcheck"
-	"github.com/ydb-platform/ydb-kubernetes-operator/internal/labels"
 	"github.com/ydb-platform/ydb-kubernetes-operator/internal/resources"
 )
 
@@ -124,11 +123,11 @@ func (r *Reconciler) waitForStatefulSetToScale(
 		return r.updateStatus(ctx, storage, StatusUpdateRequeueDelay)
 	}
 
-	found := &appsv1.StatefulSet{}
+	foundStatefulSet := &appsv1.StatefulSet{}
 	err := r.Get(ctx, types.NamespacedName{
 		Name:      storage.Name,
 		Namespace: storage.Namespace,
-	}, found)
+	}, foundStatefulSet)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			r.Recorder.Event(
@@ -148,42 +147,18 @@ func (r *Reconciler) waitForStatefulSetToScale(
 		return Stop, ctrl.Result{RequeueAfter: DefaultRequeueDelay}, err
 	}
 
-	podList := &corev1.PodList{}
-	opts := []client.ListOption{
-		client.InNamespace(storage.Namespace),
-		client.MatchingLabels{labels.StatefulsetComponent: storage.Name},
-	}
-
-	err = r.List(ctx, podList, opts...)
-	if err != nil {
-		r.Recorder.Event(
-			storage,
-			corev1.EventTypeWarning,
-			"ControllerError",
-			fmt.Sprintf("Failed to list StatefulSet pods: %s", err),
-		)
-		return Stop, ctrl.Result{RequeueAfter: DefaultRequeueDelay}, err
-	}
-
-	runningPods := 0
-	for _, e := range podList.Items {
-		if resources.PodIsReady(e) {
-			runningPods++
-		}
-	}
-
-	if runningPods != int(storage.Spec.Nodes) {
+	if foundStatefulSet.Status.ReadyReplicas != storage.Spec.Nodes {
 		r.Recorder.Event(
 			storage,
 			corev1.EventTypeNormal,
 			string(StorageProvisioning),
-			fmt.Sprintf("Waiting for number of running nodes to match expected: %d != %d", runningPods, storage.Spec.Nodes),
+			fmt.Sprintf("Waiting for number of running nodes to match expected: %d != %d", foundStatefulSet.Status.ReadyReplicas, storage.Spec.Nodes),
 		)
 		meta.SetStatusCondition(&storage.Status.Conditions, metav1.Condition{
 			Type:    StorageProvisionedCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  ReasonInProgress,
-			Message: fmt.Sprintf("Number of running nodes does not match expected: %d != %d", runningPods, storage.Spec.Nodes),
+			Message: fmt.Sprintf("Number of running nodes does not match expected: %d != %d", foundStatefulSet.Status.ReadyReplicas, storage.Spec.Nodes),
 		})
 		return r.updateStatus(ctx, storage, DefaultRequeueDelay)
 	}

--- a/internal/resources/database.go
+++ b/internal/resources/database.go
@@ -200,6 +200,9 @@ func (b *DatabaseBuilder) getNodeSetBuilders(databaseLabels labels.Labels) []Res
 		nodeSetLabels := databaseLabels.Copy()
 		nodeSetLabels.Merge(nodeSetSpecInline.Labels)
 		nodeSetLabels.Merge(map[string]string{labels.DatabaseNodeSetComponent: nodeSetSpecInline.Name})
+		if nodeSetSpecInline.Remote != nil {
+			nodeSetLabels.Merge(map[string]string{labels.RemoteClusterKey: nodeSetSpecInline.Remote.Cluster})
+		}
 
 		nodeSetAnnotations := CopyDict(b.Annotations)
 		if nodeSetSpecInline.Annotations != nil {
@@ -210,9 +213,6 @@ func (b *DatabaseBuilder) getNodeSetBuilders(databaseLabels labels.Labels) []Res
 
 		databaseNodeSetSpec := b.recastDatabaseNodeSetSpecInline(nodeSetSpecInline.DeepCopy())
 		if nodeSetSpecInline.Remote != nil {
-			nodeSetLabels = nodeSetLabels.Merge(map[string]string{
-				labels.RemoteClusterKey: nodeSetSpecInline.Remote.Cluster,
-			})
 			nodeSetBuilders = append(
 				nodeSetBuilders,
 				&RemoteDatabaseNodeSetBuilder{

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -165,6 +165,9 @@ func (b *StorageClusterBuilder) getNodeSetBuilders(storageLabels labels.Labels) 
 		nodeSetLabels := storageLabels.Copy()
 		nodeSetLabels.Merge(nodeSetSpecInline.Labels)
 		nodeSetLabels.Merge(map[string]string{labels.StorageNodeSetComponent: nodeSetSpecInline.Name})
+		if nodeSetSpecInline.Remote != nil {
+			nodeSetLabels.Merge(map[string]string{labels.RemoteClusterKey: nodeSetSpecInline.Remote.Cluster})
+		}
 
 		nodeSetAnnotations := CopyDict(b.Annotations)
 		if nodeSetSpecInline.Annotations != nil {
@@ -175,9 +178,6 @@ func (b *StorageClusterBuilder) getNodeSetBuilders(storageLabels labels.Labels) 
 
 		storageNodeSetSpec := b.recastStorageNodeSetSpecInline(nodeSetSpecInline.DeepCopy())
 		if nodeSetSpecInline.Remote != nil {
-			nodeSetLabels = nodeSetLabels.Merge(map[string]string{
-				labels.RemoteClusterKey: nodeSetSpecInline.Remote.Cluster,
-			})
 			nodeSetBuilders = append(
 				nodeSetBuilders,
 				&RemoteStorageNodeSetBuilder{


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

After changes from PR #172 controllers are waiting for recreating pods with new label `ydb.tech/statefulset-name`. WIth `strategyUpdate: OnDelete` policy usage it affect controllers by infinite loop for pods create by old generation of StatefulSet.

```
2024-07-01T09:58:40Z DEBUG events Waiting for number of running pods to match expected: 0 != 1 {"type": "Normal", "object": {"kind":"Database","namespace":"ydb-dev","name":"example-1","uid":"41243125-668b-4706-994d-6d5092f8df8f","apiVersion":"ydb.tech/v1alpha1","resourceVersion":"83370878"}, "reason": "Provisioning"}
```

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- use StatefulSet status instead of List Pod by labels inside `waitForStatefulSetToScale`
- fix missing `ydb.tech/remote-cluster` label in StatefulSet builder for Nodeset objects

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
