### PR TITLE
fix remoteObj revision field

### DIFF
--- a/.changes/unreleased/Fixed-20250127-125607.yaml
+++ b/.changes/unreleased/Fixed-20250127-125607.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: fix field resourceVersion inside .status.remoteResources.conditions
+time: 2025-01-27T12:56:07.577721+08:00

--- a/internal/controllers/remotestoragenodeset/remote_objects.go
+++ b/internal/controllers/remotestoragenodeset/remote_objects.go
@@ -60,7 +60,6 @@ func (r *Reconciler) syncRemoteObjects(
 	for _, remoteObj := range remoteObjects {
 		remoteObjName := remoteObj.GetName()
 		remoteObjKind := remoteObj.GetObjectKind().GroupVersionKind().Kind
-		remoteObjRV := remoteObj.GetResourceVersion()
 		var remoteResource *v1alpha1.RemoteResource
 		for idx := range remoteStorageNodeSet.Status.RemoteResources {
 			if resources.EqualRemoteResourceWithObject(&remoteStorageNodeSet.Status.RemoteResources[idx], remoteObj) {
@@ -103,11 +102,11 @@ func (r *Reconciler) syncRemoteObjects(
 					fmt.Sprintf("Failed to get resource %s with name %s: %s", remoteObjKind, remoteObjName, remoteGetErr),
 				)
 			}
-			remoteStorageNodeSet.UpdateRemoteResourceStatus(remoteResource, metav1.ConditionFalse, remoteObjRV)
-			return r.updateStatusRemoteObjects(ctx, remoteStorageNodeSet, DefaultRequeueDelay)
+			return Stop, ctrl.Result{RequeueAfter: DefaultRequeueDelay}, remoteGetErr
 		}
 
 		// Check object existence in local cluster
+		remoteObjRV := remoteObj.GetResourceVersion()
 		localObj := resources.CreateResource(remoteObj)
 		getErr := r.Client.Get(ctx, types.NamespacedName{
 			Name:      localObj.GetName(),
@@ -145,7 +144,7 @@ func (r *Reconciler) syncRemoteObjects(
 				"Provisioning",
 				fmt.Sprintf("RemoteSync CREATE resource %s with name %s", remoteObjKind, remoteObjName),
 			)
-			remoteStorageNodeSet.UpdateRemoteResourceStatus(remoteResource, metav1.ConditionFalse, remoteObjRV)
+			remoteStorageNodeSet.UpdateRemoteResourceStatus(remoteResource, metav1.ConditionTrue, remoteObjRV)
 			return r.updateStatusRemoteObjects(ctx, remoteStorageNodeSet, StatusUpdateRequeueDelay)
 		}
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

field `resourceVersion` inside `.status.remoteResources.conditions` does not explain actual information

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- fix field `resourceVersion` inside `.status.remoteResources.conditions` 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
