### PR TITLE
add extra volumes and extra init containers support for operator helm chart deployment

### DIFF
--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.21
+version: 0.5.22
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.21"
+appVersion: "0.5.22"

--- a/deploy/ydb-operator/templates/deployment.yaml
+++ b/deploy/ydb-operator/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - args:
             - --health-probe-bind-address=:8081
@@ -86,12 +90,19 @@ spec:
             - mountPath: /mgmt-cluster
               name: mgmt-cluster-kubeconfig
           {{- end }}
+          {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- end }}
+        {{- with .Values.extraEnvs }}
+          env:
+            {{ toYaml . | nindent 12 }}
+        {{- end }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "ydb.fullname" . }}
       terminationGracePeriodSeconds: 10
-      {{- if or .Values.webhook.enabled .Values.mgmtCluster.enabled }}
+      {{- if or .Values.webhook.enabled .Values.mgmtCluster.enabled .Values.extraVolumes }}
       volumes:
         {{- if .Values.webhook.enabled }}
         - name: webhook-tls
@@ -111,6 +122,9 @@ spec:
         - name: mgmt-cluster-kubeconfig
           secret:
             secretName: {{ .Values.mgmtCluster.kubeconfig }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- if .Values.imagePullSecrets }}

--- a/deploy/ydb-operator/values.yaml
+++ b/deploy/ydb-operator/values.yaml
@@ -119,3 +119,8 @@ webhook:
     # issuerRef:
     #   name: "issuer"
     #   kind: "ClusterIssuer"
+
+extraVolumes: []
+extraVolumeMounts: []
+extraInitContainers: []
+extraEnvs: []


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

* No way to pass extra volumes or environment variables or init containers for operator Deployment

Issue Number: N/A

## What is the new behavior?

* I added  `extraVolumes`, `extraVolumeMounts`, `extraInitContainers`, `extraEnvs` values support


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
