### PR TITLE
Cms operation

### DIFF
--- a/internal/cms/operation.go
+++ b/internal/cms/operation.go
@@ -1,0 +1,74 @@
+package cms
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ydb-platform/ydb-go-genproto/Ydb_Operation_V1"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Operations"
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/ydb-platform/ydb-kubernetes-operator/internal/connection"
+)
+
+const (
+	GetOperationTimeoutSeconds = 10
+)
+
+type Operation struct {
+	StorageEndpoint string
+	Domain          string
+	ID              string
+}
+
+func (op *Operation) GetOperation(
+	ctx context.Context,
+	opts ...ydb.Option,
+) (*Ydb_Operations.GetOperationResponse, error) {
+	logger := log.FromContext(ctx)
+
+	endpoint := fmt.Sprintf("%s/%s", op.StorageEndpoint, op.Domain)
+	ydbCtx, ydbCtxCancel := context.WithTimeout(ctx, time.Second)
+	defer ydbCtxCancel()
+	conn, err := connection.Open(ydbCtx, endpoint, ydb.MergeOptions(opts...))
+	if err != nil {
+		return nil, fmt.Errorf("error connecting to YDB: %w", err)
+	}
+	defer func() {
+		connection.Close(ydbCtx, conn)
+	}()
+
+	cmsCtx, cmsCtxCancel := context.WithTimeout(ctx, GetOperationTimeoutSeconds*time.Second)
+	defer cmsCtxCancel()
+	client := Ydb_Operation_V1.NewOperationServiceClient(ydb.GRPCConn(conn))
+	request := &Ydb_Operations.GetOperationRequest{Id: op.ID}
+
+	logger.Info("CMS GetOperation", "endpoint", endpoint, "request", request)
+	return client.GetOperation(cmsCtx, request)
+}
+
+func (op *Operation) CheckGetOperationResponse(ctx context.Context, response *Ydb_Operations.GetOperationResponse) (bool, string, error) {
+	logger := log.FromContext(ctx)
+
+	logger.Info("CMS GetOperation", "response", response)
+	return CheckOperationStatus(response.GetOperation())
+}
+
+func CheckOperationStatus(operation *Ydb_Operations.Operation) (bool, string, error) {
+	if operation == nil {
+		return false, "", ErrEmptyReplyFromStorage
+	}
+
+	if !operation.GetReady() {
+		return false, operation.Id, nil
+	}
+
+	if operation.Status == Ydb.StatusIds_ALREADY_EXISTS || operation.Status == Ydb.StatusIds_SUCCESS {
+		return true, operation.Id, nil
+	}
+
+	return true, operation.Id, fmt.Errorf("YDB response error: %v %v", operation.Status, operation.Issues)
+}

--- a/internal/cms/tenant.go
+++ b/internal/cms/tenant.go
@@ -6,15 +6,16 @@ import (
 	"fmt"
 
 	"github.com/ydb-platform/ydb-go-genproto/Ydb_Cms_V1"
-	"github.com/ydb-platform/ydb-go-genproto/Ydb_Operation_V1"
-	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Cms"
-	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Operations"
 	ydb "github.com/ydb-platform/ydb-go-sdk/v3"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	ydbv1alpha1 "github.com/ydb-platform/ydb-kubernetes-operator/api/v1alpha1"
 	"github.com/ydb-platform/ydb-kubernetes-operator/internal/connection"
+)
+
+const (
+	CreateDatabaseTimeoutSeconds = 10
 )
 
 var ErrEmptyReplyFromStorage = errors.New("empty reply from storage")
@@ -31,28 +32,34 @@ type Tenant struct {
 func (t *Tenant) Create(
 	ctx context.Context,
 	opts ...ydb.Option,
-) (string, error) {
+) (*Ydb_Cms.CreateDatabaseResponse, error) {
 	logger := log.FromContext(ctx)
-	url := fmt.Sprintf("%s/%s", t.StorageEndpoint, t.Domain)
-	conn, err := connection.Open(ctx, url, opts...)
+
+	endpoint := fmt.Sprintf("%s/%s", t.StorageEndpoint, t.Domain)
+	ydbCtx, ydbCtxCancel := context.WithTimeout(ctx, time.Second)
+	defer ydbCtxCancel()
+	conn, err := connection.Open(ydbCtx, endpoint, opts...)
 	if err != nil {
-		logger.Error(err, "Error connecting to YDB storage")
-		return "", err
+		logger.Error(err, "Error connecting to YDB")
+		return nil, err
 	}
 	defer func() {
-		connection.Close(ctx, conn)
+		connection.Close(ydbCtx, conn)
 	}()
 
+	cmsCtx, cmsCtxCancel := context.WithTimeout(ctx, CreateDatabaseTimeoutSeconds*time.Second)
+	defer cmsCtxCancel()
 	client := Ydb_Cms_V1.NewCmsServiceClient(ydb.GRPCConn(conn))
-	logger.Info(fmt.Sprintf("creating tenant, url: %s", url))
 	request := t.makeCreateDatabaseRequest()
-	logger.Info(fmt.Sprintf("creating tenant, request: %s", request))
-	response, err := client.CreateDatabase(ctx, request)
-	if err != nil {
-		return "", err
-	}
-	logger.Info(fmt.Sprintf("creating tenant, response: %s", response))
-	return processDatabaseCreationOperation(response.Operation)
+	logger.Info("CMS CreateDatabase request", "endpoint", endpoint, "request", request)
+	return client.CreateDatabase(cmsCtx, request)
+}
+
+func (t *Tenant) CheckCreateDatabaseResponse(ctx context.Context, response *Ydb_Cms.CreateDatabaseResponse) (bool, string, error) {
+	logger := log.FromContext(ctx)
+
+	logger.Info("CMS GetOperation response", "response", response)
+	return CheckOperationStatus(response.GetOperation())
 }
 
 func (t *Tenant) makeCreateDatabaseRequest() *Ydb_Cms.CreateDatabaseRequest {
@@ -86,48 +93,4 @@ func (t *Tenant) makeCreateDatabaseRequest() *Ydb_Cms.CreateDatabaseRequest {
 		}
 	}
 	return request
-}
-
-func processDatabaseCreationOperation(operation *Ydb_Operations.Operation) (string, error) {
-	if operation == nil {
-		return "", ErrEmptyReplyFromStorage
-	}
-	if !operation.Ready {
-		return operation.Id, nil
-	}
-	if operation.Status == Ydb.StatusIds_ALREADY_EXISTS || operation.Status == Ydb.StatusIds_SUCCESS {
-		return "", nil
-	}
-	return "", fmt.Errorf("YDB response error: %v %v", operation.Status, operation.Issues)
-}
-
-func (t *Tenant) CheckCreateOperation(
-	ctx context.Context,
-	operationID string,
-	opts ...ydb.Option,
-) (bool, error, error) {
-	logger := log.FromContext(ctx)
-	url := fmt.Sprintf("%s/%s", t.StorageEndpoint, t.Domain)
-	conn, err := connection.Open(ctx, url, opts...)
-	if err != nil {
-		logger.Error(err, "Error connecting to YDB storage")
-		return false, nil, err
-	}
-	defer func() {
-		connection.Close(ctx, conn)
-	}()
-
-	client := Ydb_Operation_V1.NewOperationServiceClient(ydb.GRPCConn(conn))
-	request := &Ydb_Operations.GetOperationRequest{Id: operationID}
-	logger.Info(fmt.Sprintf("checking operation, url: %s, operationId: %s, request: %s", url, operationID, request))
-	response, err := client.GetOperation(ctx, request)
-	if err != nil {
-		return false, nil, err
-	}
-	logger.Info(fmt.Sprintf("checking operation, response: %s", response))
-	if response.Operation == nil {
-		return false, nil, ErrEmptyReplyFromStorage
-	}
-	oid, err := processDatabaseCreationOperation(response.Operation)
-	return len(oid) == 0, err, nil
 }

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -45,6 +45,7 @@ const (
 	ReasonInProgress  = "InProgress"
 	ReasonNotRequired = "NotRequired"
 	ReasonCompleted   = "Completed"
+	ReasonFailed      = "Failed"
 
 	DefaultRequeueDelay                = 10 * time.Second
 	StatusUpdateRequeueDelay           = 1 * time.Second

--- a/internal/controllers/database/init.go
+++ b/internal/controllers/database/init.go
@@ -82,10 +82,18 @@ func (r *Reconciler) checkCreateDatabaseOperation(
 	if len(condition.Message) == 0 {
 		// Something is wrong with the condition where we save operation id
 		// retry create tenant
+		errMessage := fmt.Sprintf("Something is wrong with the condition, retry creating tenant %s", tenant.Path)
+		r.Recorder.Event(
+			database,
+			corev1.EventTypeWarning,
+			"InitializingFailed",
+			errMessage,
+		)
 		meta.SetStatusCondition(&database.Status.Conditions, metav1.Condition{
-			Type:   CreateDatabaseOperationCondition,
-			Status: metav1.ConditionFalse,
-			Reason: ReasonFailed,
+			Type:    CreateDatabaseOperationCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonFailed,
+			Message: errMessage,
 		})
 		return r.updateStatus(ctx, database, DatabaseInitializationRequeueDelay)
 	}
@@ -93,7 +101,7 @@ func (r *Reconciler) checkCreateDatabaseOperation(
 	operation := &cms.Operation{
 		StorageEndpoint: tenant.StorageEndpoint,
 		Domain:          tenant.Domain,
-		Id:              condition.Message,
+		ID:              condition.Message,
 	}
 	response, err := operation.GetOperation(ctx, ydbOptions)
 	if err != nil {
@@ -101,26 +109,27 @@ func (r *Reconciler) checkCreateDatabaseOperation(
 			database,
 			corev1.EventTypeWarning,
 			"InitializingFailed",
-			fmt.Sprintf("Failed to check creation operation, operationID %s: %s", operation.Id, err),
+			fmt.Sprintf("Failed to check creation operation, operationID %s: %s", operation.ID, err),
 		)
 		return Stop, ctrl.Result{RequeueAfter: DatabaseInitializationRequeueDelay}, err
 	}
 
-	finished, operationID, err := operation.CheckOperationResponse(ctx, response)
+	finished, operationID, err := operation.CheckGetOperationResponse(ctx, response)
 	if err != nil {
+		errMessage := fmt.Sprintf("Error creating tenant %s: %s", tenant.Path, err)
 		r.Recorder.Event(
 			database,
 			corev1.EventTypeWarning,
 			"InitializingFailed",
-			fmt.Sprintf("Error creating tenant %s: %s", tenant.Path, err),
+			errMessage,
 		)
 		meta.SetStatusCondition(&database.Status.Conditions, metav1.Condition{
 			Type:    CreateDatabaseOperationCondition,
 			Status:  metav1.ConditionFalse,
-			Reason:  ReasonFailed,
-			Message: fmt.Sprintf("Failed to create tenant %s", tenant.Path),
+			Reason:  ReasonCompleted,
+			Message: errMessage,
 		})
-		return Stop, ctrl.Result{RequeueAfter: DatabaseInitializationRequeueDelay}, err
+		return r.updateStatus(ctx, database, DatabaseInitializationRequeueDelay)
 	}
 
 	if !finished {
@@ -130,7 +139,13 @@ func (r *Reconciler) checkCreateDatabaseOperation(
 			string(DatabaseInitializing),
 			fmt.Sprintf("Tenant creation operation is not completed, operationID: %s", operationID),
 		)
-		return Stop, ctrl.Result{RequeueAfter: DatabaseInitializationRequeueDelay}, nil
+		meta.SetStatusCondition(&database.Status.Conditions, metav1.Condition{
+			Type:    CreateDatabaseOperationCondition,
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonInProgress,
+			Message: operationID,
+		})
+		return r.updateStatus(ctx, database, DatabaseInitializationRequeueDelay)
 	}
 
 	r.Recorder.Event(
@@ -268,7 +283,7 @@ func (r *Reconciler) initializeTenant(
 			database,
 			corev1.EventTypeWarning,
 			"InitializingFailed",
-			fmt.Sprintf("Failed %s: %s", tenant.Path, err),
+			fmt.Sprintf("Error checking operation for tenant %s: %s", tenant.Path, err),
 		)
 		return Stop, ctrl.Result{RequeueAfter: DatabaseInitializationRequeueDelay}, err
 	}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Create child context WithTimeout to use with YDB grpc connection open and CMS requests
- CMS Operation type
- Use metav1.ConditionFalse for Failed CMS Operation and metav1.ConditionUnknown for InProgress CMS Operation 
   
From [api conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties) 

> Condition type names should describe the current observed state of the resource, rather than describing the current state transitions. This typically means that the name should be an adjective ("Ready", "OutOfDisk") or a past-tense verb ("Succeeded", "Failed") rather than a present-tense verb ("Deploying"). Intermediate states may be indicated by setting the status of the condition to Unknown.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
