### PR TITLE
revert backward compatibility for encryption key secret

### DIFF
--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.23
+version: 0.5.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.23"
+appVersion: "0.5.24"

--- a/internal/resources/resource.go
+++ b/internal/resources/resource.go
@@ -61,7 +61,7 @@ const (
 	wellKnownNameForTLSCertificateAuthority = "ca.crt"
 	wellKnownNameForTLSCertificate          = "tls.crt"
 	wellKnownNameForTLSPrivateKey           = "tls.key"
-	wellKnownNameForEncryptionKeySecret     = "key.pem"
+	wellKnownNameForEncryptionKeySecret     = "key"
 
 	caBundleEnvName         = "CA_BUNDLE"
 	caBundleFileName        = "userCABundle.crt"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

key in secret for encryption changed from `key` in 0.5.22 version to `key.pem` in 0.523, that incompatible

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- revert backward compatibility for encryption key secret

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
