### PR TITLE
fix encryption config ID backward compatibility

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -30,8 +30,8 @@ const (
 	ConfigDir      = "/opt/ydb/cfg"
 	ConfigFileName = "config.yaml"
 
-	DatabaseEncryptionKeySecretDir  = "encryption"
-	DatabaseEncryptionKeySecretFile = "key.pem"
+	DatabaseEncryptionKeySecretDir  = "database_encryption"
+	DatabaseEncryptionKeySecretFile = "key"
 	DatabaseEncryptionKeyConfigFile = "key.txt"
 
 	BinariesDir      = "/opt/ydb/bin"

--- a/deploy/ydb-operator/Chart.yaml
+++ b/deploy/ydb-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.24
+version: 0.5.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.24"
+appVersion: "0.5.25"

--- a/internal/controllers/storage/controller_test.go
+++ b/internal/controllers/storage/controller_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Storage controller medium tests", func() {
 			}, &foundStorage)).Should(Succeed())
 
 			foundConfigurationChecksumAnnotation := false
-			if podAnnotations[annotations.ConfigurationChecksum] == resources.GetConfigurationChecksum(foundStorage.Spec.Configuration) {
+			if podAnnotations[annotations.ConfigurationChecksum] == resources.SHAChecksum(foundStorage.Spec.Configuration) {
 				foundConfigurationChecksumAnnotation = true
 			}
 			Expect(foundConfigurationChecksumAnnotation).To(BeTrue())

--- a/internal/resources/database.go
+++ b/internal/resources/database.go
@@ -43,7 +43,7 @@ func (b *DatabaseBuilder) GetResourceBuilders(restConfig *rest.Config) []Resourc
 	statefulSetLabels.Merge(map[string]string{labels.StatefulsetComponent: b.Name})
 
 	statefulSetAnnotations := CopyDict(b.Spec.AdditionalAnnotations)
-	statefulSetAnnotations[annotations.ConfigurationChecksum] = GetConfigurationChecksum(b.Spec.Configuration)
+	statefulSetAnnotations[annotations.ConfigurationChecksum] = SHAChecksum(b.Spec.Configuration)
 
 	grpcServiceLabels := databaseLabels.Copy()
 	grpcServiceLabels.Merge(b.Spec.Service.GRPC.AdditionalLabels)
@@ -123,7 +123,7 @@ func (b *DatabaseBuilder) GetResourceBuilders(restConfig *rest.Config) []Resourc
 						api.DatabaseEncryptionKeySecretDir,
 						api.DatabaseEncryptionKeySecretFile,
 					),
-					ID:      b.Name,
+					ID:      SHAChecksum(b.Spec.StorageClusterRef.Name),
 					Pin:     b.Spec.Encryption.Pin,
 					Version: 1,
 				},

--- a/internal/resources/databasenodeset.go
+++ b/internal/resources/databasenodeset.go
@@ -69,7 +69,7 @@ func (b *DatabaseNodeSetResource) GetResourceBuilders(restConfig *rest.Config) [
 	}
 
 	statefulSetAnnotations := CopyDict(b.Spec.AdditionalAnnotations)
-	statefulSetAnnotations[annotations.ConfigurationChecksum] = GetConfigurationChecksum(b.Spec.Configuration)
+	statefulSetAnnotations[annotations.ConfigurationChecksum] = SHAChecksum(b.Spec.Configuration)
 
 	var resourceBuilders []ResourceBuilder
 	resourceBuilders = append(resourceBuilders,

--- a/internal/resources/resource.go
+++ b/internal/resources/resource.go
@@ -564,9 +564,9 @@ func buildCAStorePatchingCommandArgs(
 	return command, args
 }
 
-func GetConfigurationChecksum(configuration string) string {
+func SHAChecksum(text string) string {
 	hasher := sha256.New()
-	hasher.Write([]byte(configuration))
+	hasher.Write([]byte(text))
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 

--- a/internal/resources/storage.go
+++ b/internal/resources/storage.go
@@ -36,7 +36,7 @@ func (b *StorageClusterBuilder) GetResourceBuilders(restConfig *rest.Config) []R
 	statefulSetLabels.Merge(map[string]string{labels.StatefulsetComponent: b.Name})
 
 	statefulSetAnnotations := CopyDict(b.Spec.AdditionalAnnotations)
-	statefulSetAnnotations[annotations.ConfigurationChecksum] = GetConfigurationChecksum(b.Spec.Configuration)
+	statefulSetAnnotations[annotations.ConfigurationChecksum] = SHAChecksum(b.Spec.Configuration)
 
 	grpcServiceLabels := storageLabels.Copy()
 	grpcServiceLabels.Merge(b.Spec.Service.GRPC.AdditionalLabels)

--- a/internal/resources/storage_init_job.go
+++ b/internal/resources/storage_init_job.go
@@ -70,7 +70,7 @@ func GetInitJobBuilder(storage *api.Storage) ResourceBuilder {
 		}
 		if storage.Spec.InitJob.AdditionalAnnotations != nil {
 			jobAnnotations = CopyDict(storage.Spec.InitJob.AdditionalAnnotations)
-			jobAnnotations[annotations.ConfigurationChecksum] = GetConfigurationChecksum(storage.Spec.Configuration)
+			jobAnnotations[annotations.ConfigurationChecksum] = SHAChecksum(storage.Spec.Configuration)
 		}
 	}
 

--- a/internal/resources/storagenodeset.go
+++ b/internal/resources/storagenodeset.go
@@ -69,7 +69,7 @@ func (b *StorageNodeSetResource) GetResourceBuilders(restConfig *rest.Config) []
 	}
 
 	statefulSetAnnotations := CopyDict(b.Spec.AdditionalAnnotations)
-	statefulSetAnnotations[annotations.ConfigurationChecksum] = GetConfigurationChecksum(b.Spec.Configuration)
+	statefulSetAnnotations[annotations.ConfigurationChecksum] = SHAChecksum(b.Spec.Configuration)
 
 	var resourceBuilders []ResourceBuilder
 	resourceBuilders = append(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The ID in encryption config was sha256 hash from Storage name before 0.5.23. After changes in [this PR](https://github.com/ydb-platform/ydb-kubernetes-operator/pull/217/files#diff-a70af5fe8d4585898406700020a1afdf04dbe29bb5ea244879b3045cf479d29fR126) there is just Database name now

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- generate encyption config with ID value of sha256 hash from Storage name for backward compatibility

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
