### PR TITLE
Enable 3 node deployment for testing purposes

### DIFF
--- a/api/v1alpha1/storage_webhook.go
+++ b/api/v1alpha1/storage_webhook.go
@@ -214,12 +214,12 @@ func (r *Storage) ValidateCreate() error {
 		None:             1,
 	}
 
-	forTestingPurposes := false
 	if r.Spec.Erasure == ErasureMirror3DC && strings.Contains(r.Spec.Configuration, "SectorMap") {
-		forTestingPurposes = true
+		// The configuration is clearly for testing purposes, three node mirror-3-dc setup is allowed
+		minNodesPerErasure[ErasureMirror3DC] = 3
 	}
 
-	if nodesNumber < minNodesPerErasure[r.Spec.Erasure] && !forTestingPurposes {
+	if nodesNumber < minNodesPerErasure[r.Spec.Erasure] {
 		return fmt.Errorf("erasure type %v requires at least %v storage nodes", r.Spec.Erasure, minNodesPerErasure[r.Spec.Erasure])
 	}
 
@@ -312,10 +312,16 @@ func (r *Storage) ValidateUpdate(old runtime.Object) error {
 	}
 
 	minNodesPerErasure := map[ErasureType]int32{
-		ErasureMirror3DC: 3,
+		ErasureMirror3DC: 9,
 		ErasureBlock42:   8,
 		None:             1,
 	}
+
+	if r.Spec.Erasure == ErasureMirror3DC && strings.Contains(r.Spec.Configuration, "SectorMap") {
+		// The configuration is clearly for testing purposes, three node mirror-3-dc setup is allowed
+		minNodesPerErasure[ErasureMirror3DC] = 3
+	}
+
 	if nodesNumber < minNodesPerErasure[r.Spec.Erasure] {
 		return fmt.Errorf("erasure type %v requires at least %v storage nodes", r.Spec.Erasure, minNodesPerErasure[r.Spec.Erasure])
 	}

--- a/api/v1alpha1/storage_webhook.go
+++ b/api/v1alpha1/storage_webhook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strings"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-cmp/cmp"
@@ -212,7 +213,13 @@ func (r *Storage) ValidateCreate() error {
 		ErasureBlock42:   8,
 		None:             1,
 	}
-	if nodesNumber < minNodesPerErasure[r.Spec.Erasure] {
+
+	forTestingPurposes := false
+	if r.Spec.Erasure == ErasureMirror3DC && strings.Contains(r.Spec.Configuration, "SectorMap") {
+		forTestingPurposes = true
+	}
+
+	if nodesNumber < minNodesPerErasure[r.Spec.Erasure] && !forTestingPurposes {
 		return fmt.Errorf("erasure type %v requires at least %v storage nodes", r.Spec.Erasure, minNodesPerErasure[r.Spec.Erasure])
 	}
 
@@ -305,7 +312,7 @@ func (r *Storage) ValidateUpdate(old runtime.Object) error {
 	}
 
 	minNodesPerErasure := map[ErasureType]int32{
-		ErasureMirror3DC: 9,
+		ErasureMirror3DC: 3,
 		ErasureBlock42:   8,
 		None:             1,
 	}

--- a/api/v1alpha1/storage_webhook.go
+++ b/api/v1alpha1/storage_webhook.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"strings"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-cmp/cmp"
@@ -209,14 +208,9 @@ func (r *Storage) ValidateCreate() error {
 	}
 
 	minNodesPerErasure := map[ErasureType]int32{
-		ErasureMirror3DC: 9,
+		ErasureMirror3DC: 3,
 		ErasureBlock42:   8,
 		None:             1,
-	}
-
-	if r.Spec.Erasure == ErasureMirror3DC && strings.Contains(r.Spec.Configuration, "SectorMap") {
-		// The configuration is clearly for testing purposes, three node mirror-3-dc setup is allowed
-		minNodesPerErasure[ErasureMirror3DC] = 3
 	}
 
 	if nodesNumber < minNodesPerErasure[r.Spec.Erasure] {
@@ -312,14 +306,9 @@ func (r *Storage) ValidateUpdate(old runtime.Object) error {
 	}
 
 	minNodesPerErasure := map[ErasureType]int32{
-		ErasureMirror3DC: 9,
+		ErasureMirror3DC: 3,
 		ErasureBlock42:   8,
 		None:             1,
-	}
-
-	if r.Spec.Erasure == ErasureMirror3DC && strings.Contains(r.Spec.Configuration, "SectorMap") {
-		// The configuration is clearly for testing purposes, three node mirror-3-dc setup is allowed
-		minNodesPerErasure[ErasureMirror3DC] = 3
 	}
 
 	if nodesNumber < minNodesPerErasure[r.Spec.Erasure] {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

webhook sees mirror-3-dc erasure and forbids anything below 9 nodes

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- allow `mirror-3-dc` erasure if the `SectorMap` string is present within the configuration
