### PR TITLE
append secrets and volumes from storage spec to init-job volumes

### DIFF
--- a/.changes/unreleased/Fixed-20250129-134226.yaml
+++ b/.changes/unreleased/Fixed-20250129-134226.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Passing additional secret volumes to blobstorage-init. The init container can now use them without issues.
+time: 2025-01-29T13:42:26.145577+01:00

--- a/internal/resources/database_statefulset.go
+++ b/internal/resources/database_statefulset.go
@@ -192,7 +192,7 @@ func (b *DatabaseStatefulSetBuilder) buildVolumes() []corev1.Volume {
 	}
 
 	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
-		volumes = append(volumes, buildTLSVolume(grpcTLSVolumeName, b.Spec.Service.GRPC.TLSConfiguration))
+		volumes = append(volumes, buildTLSVolume(GRPCTLSVolumeName, b.Spec.Service.GRPC.TLSConfiguration))
 	}
 
 	if b.Spec.Service.Interconnect.TLSConfiguration.Enabled {
@@ -314,7 +314,7 @@ func (b *DatabaseStatefulSetBuilder) buildCaStorePatchingInitContainerVolumeMoun
 
 	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      grpcTLSVolumeName,
+			Name:      GRPCTLSVolumeName,
 			ReadOnly:  true,
 			MountPath: grpcTLSVolumeMountPath,
 		})
@@ -482,7 +482,7 @@ func (b *DatabaseStatefulSetBuilder) buildVolumeMounts() []corev1.VolumeMount {
 
 	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      grpcTLSVolumeName,
+			Name:      GRPCTLSVolumeName,
 			ReadOnly:  true,
 			MountPath: grpcTLSVolumeMountPath,
 		})

--- a/internal/resources/resource.go
+++ b/internal/resources/resource.go
@@ -35,7 +35,7 @@ const (
 	StatusServiceNameFormat       = "%s-status"
 	DatastreamsServiceNameFormat  = "%s-datastreams"
 
-	grpcTLSVolumeName         = "grpc-tls-volume"
+	GRPCTLSVolumeName         = "grpc-tls-volume"
 	interconnectTLSVolumeName = "interconnect-tls-volume"
 	datastreamsTLSVolumeName  = "datastreams-tls-volume"
 	statusTLSVolumeName       = "status-tls-volume"

--- a/internal/resources/storage_init_job.go
+++ b/internal/resources/storage_init_job.go
@@ -137,7 +137,7 @@ func (b *StorageInitJobBuilder) buildInitJobVolumes() []corev1.Volume {
 	}
 
 	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
-		volumes = append(volumes, buildTLSVolume(grpcTLSVolumeName, b.Spec.Service.GRPC.TLSConfiguration))
+		volumes = append(volumes, buildTLSVolume(GRPCTLSVolumeName, b.Spec.Service.GRPC.TLSConfiguration))
 	}
 
 	if b.Spec.OperatorConnection != nil {
@@ -234,7 +234,7 @@ func (b *StorageInitJobBuilder) buildJobVolumeMounts() []corev1.VolumeMount {
 
 	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      grpcTLSVolumeName,
+			Name:      GRPCTLSVolumeName,
 			ReadOnly:  true,
 			MountPath: grpcTLSVolumeMountPath,
 		})
@@ -317,7 +317,7 @@ func (b *StorageInitJobBuilder) buildCaStorePatchingInitContainerVolumeMounts() 
 
 	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      grpcTLSVolumeName,
+			Name:      GRPCTLSVolumeName,
 			ReadOnly:  true,
 			MountPath: grpcTLSVolumeMountPath,
 		})

--- a/internal/resources/storage_init_job.go
+++ b/internal/resources/storage_init_job.go
@@ -75,6 +75,7 @@ func (b *StorageInitJobBuilder) buildInitJobPodTemplateSpec() corev1.PodTemplate
 			DNSConfig: &corev1.PodDNSConfig{
 				Searches: dnsConfigSearches,
 			},
+			InitContainers: b.Spec.InitContainers,
 		},
 	}
 
@@ -92,8 +93,7 @@ func (b *StorageInitJobBuilder) buildInitJobPodTemplateSpec() corev1.PodTemplate
 		}
 	}
 
-	// InitContainer only needed for CaBundle manipulation for now,
-	// may be probably used for other stuff later
+	// append an init container for updating the ca.crt if we have any certificates
 	if b.AnyCertificatesAdded() {
 		podTemplate.Spec.InitContainers = append(
 			[]corev1.Container{b.buildCaStorePatchingInitContainer()},

--- a/internal/resources/storage_init_job.go
+++ b/internal/resources/storage_init_job.go
@@ -153,6 +153,21 @@ func (b *StorageInitJobBuilder) buildInitJobVolumes() []corev1.Volume {
 			})
 	}
 
+	for _, secret := range b.Spec.Secrets {
+		volumes = append(volumes, corev1.Volume{
+			Name: secret.Name,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secret.Name,
+				},
+			},
+		})
+	}
+
+	for _, volume := range b.Spec.Volumes {
+		volumes = append(volumes, *volume)
+	}
+
 	if b.AnyCertificatesAdded() {
 		volumes = append(volumes, corev1.Volume{
 			Name: systemCertsVolumeName,

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -216,7 +216,7 @@ func (b *StorageStatefulSetBuilder) buildVolumes() []corev1.Volume {
 	}
 
 	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
-		volumes = append(volumes, buildTLSVolume(grpcTLSVolumeName, b.Spec.Service.GRPC.TLSConfiguration))
+		volumes = append(volumes, buildTLSVolume(GRPCTLSVolumeName, b.Spec.Service.GRPC.TLSConfiguration))
 	}
 
 	if b.Spec.Service.Interconnect.TLSConfiguration.Enabled {
@@ -326,7 +326,7 @@ func (b *StorageStatefulSetBuilder) buildCaStorePatchingInitContainerVolumeMount
 
 	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      grpcTLSVolumeName,
+			Name:      GRPCTLSVolumeName,
 			ReadOnly:  true,
 			MountPath: grpcTLSVolumeMountPath,
 		})
@@ -438,7 +438,7 @@ func (b *StorageStatefulSetBuilder) buildVolumeMounts() []corev1.VolumeMount {
 
 	if b.Spec.Service.GRPC.TLSConfiguration.Enabled {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      grpcTLSVolumeName,
+			Name:      GRPCTLSVolumeName,
 			ReadOnly:  true,
 			MountPath: grpcTLSVolumeMountPath,
 		})

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -768,6 +768,82 @@ var _ = Describe("Operator smoke test", func() {
 		ExecuteSimpleTableE2ETestWithSDK(databaseSample.Name, testobjects.YdbNamespace, databasePath)
 	})
 
+	It("Check init job has additional volumes", func() {
+		By("create storage tls secret...")
+		storageCert := testobjects.StorageCertificate()
+		Expect(k8sClient.Create(ctx, storageCert)).Should(Succeed())
+
+		By("create storage...")
+		storage := testobjects.DefaultStorage(filepath.Join("..", "data", "storage-mirror-3-dc-config.yaml"))
+
+		secretName := testobjects.StorageCertificateSecretName
+		secretPath := fmt.Sprintf("%s/%s", resources.wellKnownDirForAdditionalSecrets, secretName)
+
+		storage.Spec.Secrets = []*corev1.LocalObjectReference{
+			{
+				Name: secretName,
+			},
+		}
+
+		storage.Spec.InitContainers = []corev1.Container{
+			{
+				Name:    "init-container",
+				Image:   storage.Spec.Image.Name,
+				Command: []string{"bash", "-xc"},
+				Args:    []string{fmt.Sprintf("ls -la %s", secretPath)},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      secretName,
+						MountPath: secretPath,
+						ReadOnly:  true,
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, storage)).Should(Succeed())
+		defer DeleteStorageSafely(ctx, k8sClient, storage)
+
+		By("waiting until Storage is ready ...")
+		WaitUntilStorageReady(ctx, k8sClient, storage.Name, testobjects.YdbNamespace)
+	})
+
+	It("Check init job has additional volumes with GRPCS enabled", func() {
+		By("create storage tls secret...")
+		storageCert := testobjects.StorageCertificate()
+		Expect(k8sClient.Create(ctx, storageCert)).Should(Succeed())
+
+		By("create storage...")
+		storage := testobjects.DefaultStorage(filepath.Join("..", "data", "storage-mirror-3-dc-config-tls.yaml"))
+
+		secretName := testobjects.StorageCertificateSecretName
+		secretPath := fmt.Sprintf("%s/%s", resources.wellKnownDirForAdditionalSecrets, secretName)
+
+		storage.Spec.Service.GRPC.TLSConfiguration = testobjects.TLSConfiguration(secretName)
+
+		storage.Spec.InitContainers = []corev1.Container{
+			{
+				Name:    "init-container",
+				Image:   storage.Spec.Image.Name,
+				Command: []string{"bash", "-xc"},
+				Args:    []string{fmt.Sprintf("ls -la %s", secretPath)},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      resources.grpcTLSVolumeName,
+						MountPath: secretPath,
+						ReadOnly:  true,
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, storage)).Should(Succeed())
+		defer DeleteStorageSafely(ctx, k8sClient, storage)
+
+		By("waiting until Storage is ready ...")
+		WaitUntilStorageReady(ctx, k8sClient, storage.Name, testobjects.YdbNamespace)
+	})
+
 	AfterEach(func() {
 		UninstallOperatorWithHelm(testobjects.YdbNamespace)
 		Expect(k8sClient.Delete(ctx, &namespace)).Should(Succeed())

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -777,7 +777,7 @@ var _ = Describe("Operator smoke test", func() {
 		storage := testobjects.DefaultStorage(filepath.Join("..", "data", "storage-mirror-3-dc-config.yaml"))
 
 		secretName := testobjects.StorageCertificateSecretName
-		secretPath := fmt.Sprintf("%s/%s", resources.wellKnownDirForAdditionalSecrets, secretName)
+		secretPath := fmt.Sprintf("%s/%s", v1alpha1.AdditionalSecretsDir, secretName)
 
 		storage.Spec.Secrets = []*corev1.LocalObjectReference{
 			{
@@ -817,7 +817,7 @@ var _ = Describe("Operator smoke test", func() {
 		storage := testobjects.DefaultStorage(filepath.Join("..", "data", "storage-mirror-3-dc-config-tls.yaml"))
 
 		secretName := testobjects.StorageCertificateSecretName
-		secretPath := fmt.Sprintf("%s/%s", resources.wellKnownDirForAdditionalSecrets, secretName)
+		secretPath := fmt.Sprintf("%s/%s", v1alpha1.AdditionalSecretsDir, secretName)
 
 		storage.Spec.Service.GRPC.TLSConfiguration = testobjects.TLSConfiguration(secretName)
 
@@ -829,7 +829,7 @@ var _ = Describe("Operator smoke test", func() {
 				Args:    []string{fmt.Sprintf("ls -la %s", secretPath)},
 				VolumeMounts: []corev1.VolumeMount{
 					{
-						Name:      resources.grpcTLSVolumeName,
+						Name:      resources.GRPCTLSVolumeName,
 						MountPath: secretPath,
 						ReadOnly:  true,
 					},

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -768,47 +768,7 @@ var _ = Describe("Operator smoke test", func() {
 		ExecuteSimpleTableE2ETestWithSDK(databaseSample.Name, testobjects.YdbNamespace, databasePath)
 	})
 
-	It("Check init job has additional volumes", func() {
-		By("create storage tls secret...")
-		storageCert := testobjects.StorageCertificate()
-		Expect(k8sClient.Create(ctx, storageCert)).Should(Succeed())
-
-		By("create storage...")
-		storage := testobjects.DefaultStorage(filepath.Join("..", "data", "storage-mirror-3-dc-config.yaml"))
-
-		secretName := testobjects.StorageCertificateSecretName
-		secretPath := fmt.Sprintf("%s/%s", v1alpha1.AdditionalSecretsDir, secretName)
-
-		storage.Spec.Secrets = []*corev1.LocalObjectReference{
-			{
-				Name: secretName,
-			},
-		}
-
-		storage.Spec.InitContainers = []corev1.Container{
-			{
-				Name:    "init-container",
-				Image:   storage.Spec.Image.Name,
-				Command: []string{"bash", "-xc"},
-				Args:    []string{fmt.Sprintf("ls -la %s", secretPath)},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      secretName,
-						MountPath: secretPath,
-						ReadOnly:  true,
-					},
-				},
-			},
-		}
-
-		Expect(k8sClient.Create(ctx, storage)).Should(Succeed())
-		defer DeleteStorageSafely(ctx, k8sClient, storage)
-
-		By("waiting until Storage is ready ...")
-		WaitUntilStorageReady(ctx, k8sClient, storage.Name, testobjects.YdbNamespace)
-	})
-
-	It("Check init job has additional volumes with GRPCS enabled", func() {
+	It("Check init job with additional volumes and GRPCS enabled", func() {
 		By("create storage tls secret...")
 		storageCert := testobjects.StorageCertificate()
 		Expect(k8sClient.Create(ctx, storageCert)).Should(Succeed())


### PR DESCRIPTION
Now is impossible to run init-job if you  have storage init container and this init container is using some files from secrets or volumes. This PR fixes this by adding secrets and volumes declared in storage spec to init-job volumes

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

```
Warning  InitializingStorage  10s (x12 over 21s)  Storage  Failed to create init blobstorage Job, error: Job.batch "storage-blobstorage-init" is invalid: spec.template.spec.initContainers[1].volumeMounts[2].name: Not found: "trust-bundle"
```

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
