### PR TITLE
use oldObj as statefulSet inside IgnoreChangesFunction

### DIFF
--- a/.changes/unreleased/Fixed-20250127-141003.yaml
+++ b/.changes/unreleased/Fixed-20250127-141003.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: panic when create object with .spec.pause is true
+time: 2025-01-27T14:10:03.497565+08:00

--- a/internal/controllers/database/sync.go
+++ b/internal/controllers/database/sync.go
@@ -359,8 +359,8 @@ func (r *Reconciler) waitForStatefulSetToScale(
 
 func shouldIgnoreDatabaseChange(database *resources.DatabaseBuilder) resources.IgnoreChangesFunction {
 	return func(oldObj, newObj runtime.Object) bool {
-		if _, ok := newObj.(*appsv1.StatefulSet); ok {
-			if database.Spec.Pause && *oldObj.(*appsv1.StatefulSet).Spec.Replicas == 0 {
+		if statefulSet, ok := oldObj.(*appsv1.StatefulSet); ok {
+			if database.Spec.Pause && *statefulSet.Spec.Replicas == 0 {
 				return true
 			}
 		}

--- a/internal/controllers/storage/sync.go
+++ b/internal/controllers/storage/sync.go
@@ -292,8 +292,8 @@ func (r *Reconciler) waitForNodeSetsToProvisioned(
 
 func shouldIgnoreStorageChange(storage *resources.StorageClusterBuilder) resources.IgnoreChangesFunction {
 	return func(oldObj, newObj runtime.Object) bool {
-		if _, ok := newObj.(*appsv1.StatefulSet); ok {
-			if storage.Spec.Pause && *oldObj.(*appsv1.StatefulSet).Spec.Replicas == 0 {
+		if statefulSet, ok := newObj.(*appsv1.StatefulSet); ok {
+			if storage.Spec.Pause && *statefulSet.Spec.Replicas == 0 {
 				return true
 			}
 		}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #285 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-  use `oldObj` as statefulSet inside `IgnoreChangesFunction`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
