### PR TITLE
Allow dispatching `compatibility-tests` workflow from `upload-artifacts`

### DIFF
--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -1,10 +1,9 @@
 name: compatibility-tests
 
 on:
-  push:
-    tags:
-      - '*'
   workflow_dispatch:
+  repository_dispatch:
+    types: [compatibility-tests]
 
 jobs:
   test-compatibility:
@@ -55,6 +54,9 @@ jobs:
           if [ "$PREVIOUS_VERSION" = "0.4.42" ]; then
             PREVIOUS_VERSION="0.5.30"
           fi
+
+          echo "Current version is $NEW_VERSION"
+          echo "Will be tested for compatibility from $PREVIOUS_VERSION"
 
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
           echo "PREVIOUS_VERSION=$PREVIOUS_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/tmp-workflow.yaml
+++ b/.github/workflows/tmp-workflow.yaml
@@ -1,0 +1,18 @@
+name: tmp
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: dispatch-compatibility-tests
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        event-type: compatibility-tests

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -29,11 +29,6 @@ jobs:
         custom_tag: ${{ env.VERSION }}
         github_token: ${{ github.token }}
 
-    - name: dispatch-compatibility-tests
-      uses: peter-evans/repository-dispatch@v3
-      with:
-        event-type: compatibility-tests
-
     - name: install-dependencies
       run: |
         HELM_PKG="helm-v3.10.3-linux-amd64.tar.gz"
@@ -136,3 +131,8 @@ jobs:
         tag_name: ${{ env.VERSION }} 
       env:
         GITHUB_TOKEN: ${{ github.token }}
+
+    - name: dispatch-compatibility-tests
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        event-type: compatibility-tests

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -29,6 +29,11 @@ jobs:
         custom_tag: ${{ env.VERSION }}
         github_token: ${{ github.token }}
 
+    - name: dispatch-compatibility-tests
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        event-type: compatibility-tests
+
     - name: install-dependencies
       run: |
         HELM_PKG="helm-v3.10.3-linux-amd64.tar.gz"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

For security reasons, `compatibility-tests` workflow was not triggered after `upload-artifacts` workflow created a tag.
We must manually dispatch compatibility test workflow after creating a tag
