### PR TITLE
fix blobstorage-init-job, fix passing interconnect volume

### DIFF
--- a/.changes/unreleased/Fixed-20250210-112112.yaml
+++ b/.changes/unreleased/Fixed-20250210-112112.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: fix passing interconnet TLS volume in blobstorage-init job
+time: 2025-02-10T11:21:12.37515+01:00


### PR DESCRIPTION
Fix incorrect behaviour when no TLS interconnect volume mount is passed for ydb-blobstorage-init. Also, a small refactor of the append volumeMounts code.

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently we don't add an interconnect TLS volume mount.

Issue Number: N/A

## What is the new behavior?

Add TLS interconnect volume mount for ydb-blobstorage-init

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
