### PR TITLE
set updateStrategy: OnDelete for Storage StatefulSet by default

### DIFF
--- a/.changes/unreleased/Changed-20250224-104818.yaml
+++ b/.changes/unreleased/Changed-20250224-104818.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'set updateStrategy: OnDelete for Storage StatefulSet by default'
+time: 2025-02-24T10:48:18.815104+08:00

--- a/internal/resources/database_statefulset.go
+++ b/internal/resources/database_statefulset.go
@@ -62,7 +62,7 @@ func (b *DatabaseStatefulSetBuilder) Build(obj client.Object) error {
 
 	if value, ok := b.ObjectMeta.Annotations[api.AnnotationUpdateStrategyOnDelete]; ok && value == api.AnnotationValueTrue {
 		sts.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
-			Type: "OnDelete",
+			Type: appsv1.OnDeleteStatefulSetStrategyType,
 		}
 	}
 

--- a/internal/resources/storage_statefulset.go
+++ b/internal/resources/storage_statefulset.go
@@ -72,16 +72,13 @@ func (b *StorageStatefulSetBuilder) Build(obj client.Object) error {
 				labels.StatefulsetComponent: b.Name,
 			},
 		},
+		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+			Type: appsv1.OnDeleteStatefulSetStrategyType,
+		},
 		PodManagementPolicy:  appsv1.ParallelPodManagement,
 		RevisionHistoryLimit: ptr.Int32(10),
 		ServiceName:          fmt.Sprintf(InterconnectServiceNameFormat, b.Storage.Name),
 		Template:             b.buildPodTemplateSpec(),
-	}
-
-	if value, ok := b.ObjectMeta.Annotations[api.AnnotationUpdateStrategyOnDelete]; ok && value == api.AnnotationValueTrue {
-		sts.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
-			Type: "OnDelete",
-		}
 	}
 
 	pvcList := make([]corev1.PersistentVolumeClaim, 0, len(b.Spec.DataStore))


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): "changes default logic"

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- used default StatefulSet `updateStrategy` for Storage resources is `RollingUpdate`

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- changes default StatefulSet `updateStrategy` for Storage resources to `OnDelete`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

In order to avoid an uncontrolled restart of Storage pods while changing command line arguments/environment variables (for example, when updating the operator version), we should avoid using the current default "RollingUpdate" update type. Only this mode can be applied while the feature with restarts using k8s controllers and CMS permissions does not implemented yet.

