### PR TITLE
Fix `operatorSync: false` breaking on implicit webhook mutations

### DIFF
--- a/api/v1alpha1/storage_webhook.go
+++ b/api/v1alpha1/storage_webhook.go
@@ -116,10 +116,6 @@ func (r *StorageDefaulter) Default(ctx context.Context, obj runtime.Object) erro
 	storage := obj.(*Storage)
 	storagelog.Info("default", "name", storage.Name)
 
-	if !storage.Spec.OperatorSync {
-		return nil
-	}
-
 	if storage.Spec.OperatorConnection != nil {
 		if storage.Spec.OperatorConnection.Oauth2TokenExchange != nil {
 			if storage.Spec.OperatorConnection.Oauth2TokenExchange.SignAlg == "" {

--- a/api/v1alpha1/storage_webhook.go
+++ b/api/v1alpha1/storage_webhook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"reflect"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-cmp/cmp"
@@ -115,10 +116,6 @@ type StorageDefaulter struct {
 func (r *StorageDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	storage := obj.(*Storage)
 	storagelog.Info("default", "name", storage.Name)
-
-	if !storage.Spec.OperatorSync {
-		return nil
-	}
 
 	if storage.Spec.OperatorConnection != nil {
 		if storage.Spec.OperatorConnection.Oauth2TokenExchange != nil {
@@ -311,9 +308,38 @@ func hasUpdatesBesidesFrozen(oldStorage, newStorage *Storage) (bool, string) {
 	oldStorageCopy.Spec.OperatorSync = false
 	newStorageCopy.Spec.OperatorSync = false
 
-	ignoreNonSpecFields := cmpopts.IgnoreFields(Storage{}, "Status", "ObjectMeta", "TypeMeta")
+	// We will allow configuration diffs if they are limited to
+	// formatting, order of keys in the map etc. If two maps are
+	// meaningfully different (not deep-equal), we still disallow
+	// the diff of course.
+	configurationCompareOpt := cmp.FilterPath(
+		func(path cmp.Path) bool {
+			if sf, ok := path.Last().(cmp.StructField); ok {
+				return sf.Name() == "Configuration"
+			}
+			return false
+		},
+		cmp.Comparer(func(a, b string) bool {
+			var o1, o2 any
 
-	diff := cmp.Diff(oldStorageCopy, newStorageCopy, ignoreNonSpecFields)
+			if err := yaml.Unmarshal([]byte(a), &o1); err != nil {
+				return false
+			}
+			if err := yaml.Unmarshal([]byte(b), &o2); err != nil {
+				return false
+			}
+
+			return reflect.DeepEqual(o1, o2)
+		}),
+	)
+
+	ignoreNonSpecFields := cmpopts.IgnoreFields(Storage{}, "Status", "ObjectMeta", "TypeMeta")
+	diff := cmp.Diff(
+		oldStorageCopy,
+		newStorageCopy,
+		ignoreNonSpecFields,
+		configurationCompareOpt,
+	)
 	return diff != "", diff
 }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix

## What is the current behavior?

- when setting `operatorSync: false`, validating webhook checks for any other checks besides this field. It fails because in mutating webhook marshalling + unmarshalling of `spec.configuration` occurs, and it is not a noop (formatting changes)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- validating webhook compares configuration correctly, without failing on formatting only 
